### PR TITLE
Fix CWE detection bug for CVE records with embedded CWE IDs in description text

### DIFF
--- a/cnascorecard_pipeline/completeness.py
+++ b/cnascorecard_pipeline/completeness.py
@@ -155,10 +155,28 @@ def _custom_check(data: Any, check_type: str) -> bool:
     # ProblemTypes
     if check_type == "has_cwe":
         if isinstance(data, list):
-            return any(
-                any("cweId" in d for d in pt.get("descriptions", []))
-                for pt in data if isinstance(pt, dict)
-            )
+            import re
+            cwe_pattern = re.compile(r'CWE-\d+', re.IGNORECASE)
+            
+            for pt in data:
+                if not isinstance(pt, dict):
+                    continue
+                
+                descriptions = pt.get("descriptions", [])
+                for desc in descriptions:
+                    if not isinstance(desc, dict):
+                        continue
+                    
+                    # Check for explicit cweId field (existing logic)
+                    if "cweId" in desc:
+                        return True
+                    
+                    # Check for CWE ID embedded in description text (new logic)
+                    desc_text = desc.get("description", "")
+                    if desc_text and cwe_pattern.search(desc_text):
+                        return True
+            
+            return False
         return False
     if check_type == "has_type":
         if isinstance(data, list):


### PR DESCRIPTION
## 🐛 Bug Fix: WPScan CNA showing 0% CWE data despite having CWE information

### Issue Description
The CNAGradeCard was displaying **0% Root Cause Analysis (CWE)** for WPScan CNA, even though their CVE records contain proper CWE data. For example, [CVE-2025-5921](https://www.cve.org/CVERecord?id=CVE-2025-5921) clearly shows "CWE-79 Cross-Site Scripting (XSS)" but the scorecard wasn't detecting it.

**Problem URL:** https://cnascorecard.org/cna/cna-detail.html?shortName=WPScan

### Root Cause Analysis
The issue was caused by **data format variation** between different CNAs:

**Format 1 (Most CNAs):** Explicit `cweId` field
```json
{
  "descriptions": [{
    "cweId": "CWE-79",
    "description": "CWE-79 Cross-site Scripting (XSS)",
    "lang": "en",
    "type": "CWE"
  }]
}
```

Format 2 (WPScan & Others): CWE embedded in description text only.

```json
{
  "descriptions": [{
    "description": "CWE-79 Cross-Site Scripting (XSS)",
    "lang": "en", 
    "type": "CWE"
  }]
}
```

The original has_cwe function in `completeness.py` only checked for explicit cweId fields, missing the embedded format used by WPScan.

### Solution
Enhanced the  `_custom_check()`function with:

Backward Compatibility: Still checks for explicit cweId fields first

Enhanced Detection: Added regex pattern matching (CWE-\d+) to detect CWE IDs in description text
Fallback Logic: Uses description text parsing when cweId field is absent

Code Changes

```python
# Added regex pattern matching for embedded CWE IDs
import re
cwe_pattern = re.compile(r'CWE-\d+', re.IGNORECASE)

# Enhanced detection logic with fallback

for desc in descriptions:
    # Check for explicit cweId field (existing logic)
    if "cweId" in desc:
        return True
    
    # Check for CWE ID embedded in description text (new logic)
    desc_text = desc.get("description", "")
    if desc_text and cwe_pattern.search(desc_text):
        return True
 ```       