### PR TITLE
Clarify patch scoring description to match implementation

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,547 +1,620 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MQJ07VQQQN"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
+  <head>
+    <!-- Google tag (gtag.js) -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-MQJ07VQQQN"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
 
-    gtag('config', 'G-MQJ07VQQQN');
-  </script>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="CNA Scorecard measures CVE data quality across 300+ CVE Numbering Authorities with transparent scoring and rankings.">
-  <link rel="canonical" href="https://cnascorecard.org/">
-  <title>CNA Scorecard</title>
-  <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
-  <link rel="icon" type="image/png" href="assets/logo.svg">
-  <link rel="stylesheet" href="assets/theme.css">
-  <link rel="stylesheet" href="shared/shared.css">
-  <script src="https://cdn.jsdelivr.net/npm/chart.js" async></script>
-  <style>
-    /* Homepage-specific styles */
-    .container {
-      max-width: 1200px;
-      margin: 0 auto;
-      padding: 2rem 1rem;
-    }
-    
-    .page-header {
-      background-color: var(--card-bg);
-      border-radius: 12px;
-      padding: 2rem;
-      margin-bottom: 2rem;
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
-      text-align: center;
-    }
-    
-    .page-title {
-      font-size: 2.5rem;
-      color: var(--primary-color);
-      margin-bottom: 1rem;
-      font-weight: 600;
-    }
-    
-    .page-subtitle {
-      color: var(--text-secondary);
-      font-size: 1.1rem;
-      margin: 0 auto 2rem;
-      line-height: 1.6;
-      max-width: 900px;
-    }
-    
-    .cta-buttons {
-      display: flex;
-      gap: 1rem;
-      justify-content: center;
-      flex-wrap: wrap;
-    }
-    
-    .cta-button {
-      padding: 1rem 2rem;
-      border-radius: 8px;
-      text-decoration: none;
-      font-weight: 600;
-      transition: all 0.3s ease;
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-    }
-    
-    .cta-button.primary {
-      background: var(--primary-color);
-      color: white;
-    }
-    
-    .cta-button.secondary {
-      background: var(--card-bg);
-      color: var(--text-primary);
-      border: 1px solid var(--border-color);
-    }
-    
-    .cta-button:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 8px 25px rgba(0, 0, 0, 0.2);
-    }
-    
-    .stats-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-      gap: 1.5rem;
-    }
-    
-    .stat-card {
-      background: var(--card-bg);
-      padding: 1.5rem;
-      border-radius: 8px;
-      border: 1px solid var(--border-color);
-      text-align: center;
-      transition: transform 0.2s ease, box-shadow 0.2s ease;
-    }
-    
-    .stat-card:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 6px 20px rgba(0, 0, 0, 0.1);
-    }
-    
-    .stat-value {
-      font-size: 2.5rem;
-      font-weight: 700;
-      color: var(--primary-color);
-      margin-bottom: 0.5rem;
-    }
-    
-    .stat-label {
-      color: var(--text-secondary);
-      font-size: 0.9rem;
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
-    }
-    
-    /* Date range styling */
-    .date-separator {
-      color: #ccc;
-      margin: 0 0.5rem;
-      font-weight: 300;
-      font-size: 0.9em;
-    }
-    
-    .date-start, .date-end {
-      display: inline-block;
-    }
-    
-    .section {
-      background-color: var(--card-bg);
-      border-radius: 12px;
-      padding: 2rem;
-      margin-bottom: 2rem;
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
-    }
-    
-    .section-title {
-      font-size: 1.75rem;
-      font-weight: 600;
-      margin-bottom: 1.5rem;
-      text-align: center;
-      color: var(--primary-color);
-    }
-    
-    .two-column {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 3rem;
-      align-items: center;
-    }
-    
-    .chart-container {
-      background: var(--card-bg);
-      padding: 2rem;
-      border-radius: 12px;
-      border: 1px solid var(--border-color);
-    }
-    
-    .chart-canvas {
-      width: 100%;
-      height: 400px;
-    }
-    
-    .performance-columns {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 1.5rem;
-    }
-    
-    .performance-column {
-      background: var(--card-bg);
-      padding: 1.5rem;
-      border-radius: 8px;
-      border: 1px solid var(--border-color);
-    }
-    
-    .performance-column h3 {
-      margin-bottom: 1.5rem;
-      color: var(--text-primary);
-      font-size: 1.25rem;
-    }
-    
-    .cna-item {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: 0.75rem 0;
-      border-bottom: 1px solid var(--border-color);
-    }
-    
-    .cna-item:last-child {
-      border-bottom: none;
-    }
-    
-    .cna-name {
-      color: var(--primary-color);
-      text-decoration: none;
-      font-weight: 500;
-    }
-    
-    .cna-name:hover {
-      text-decoration: underline;
-    }
-    
-    .cna-score {
-      font-weight: 600;
-      color: var(--text-secondary);
-    }
-    
-    .centered-cta {
-      text-align: center;
-      margin-top: 2rem;
-    }
-    
-    .category-grid {
-      display: grid;
-      grid-template-columns: repeat(6, 1fr);
-      gap: 2rem;
-      margin-top: 2rem;
-    }
-    
-    .category-grid .category-card:nth-child(1) {
-      grid-column: 1 / 3;
-    }
-    
-    .category-grid .category-card:nth-child(2) {
-      grid-column: 3 / 5;
-    }
-    
-    .category-grid .category-card:nth-child(3) {
-      grid-column: 5 / 7;
-    }
-    
-    .category-grid .category-card:nth-child(4) {
-      grid-column: 2 / 4;
-      grid-row: 2;
-    }
-    
-    .category-grid .category-card:nth-child(5) {
-      grid-column: 4 / 6;
-      grid-row: 2;
-    }
-    
-    @media (max-width: 1024px) {
-      .category-grid {
-        grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gtag("config", "G-MQJ07VQQQN");
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="CNA Scorecard measures CVE data quality across 300+ CVE Numbering Authorities with transparent scoring and rankings."
+    />
+    <link rel="canonical" href="https://cnascorecard.org/" />
+    <title>CNA Scorecard</title>
+    <link rel="icon" type="image/svg+xml" href="assets/logo.svg" />
+    <link rel="icon" type="image/png" href="assets/logo.svg" />
+    <link rel="stylesheet" href="assets/theme.css" />
+    <link rel="stylesheet" href="shared/shared.css" />
+    <script src="https://cdn.jsdelivr.net/npm/chart.js" async></script>
+    <style>
+      /* Homepage-specific styles */
+      .container {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 2rem 1rem;
       }
-      
-      .category-grid .category-card:nth-child(1),
-      .category-grid .category-card:nth-child(2),
-      .category-grid .category-card:nth-child(3),
-      .category-grid .category-card:nth-child(4),
-      .category-grid .category-card:nth-child(5) {
-        grid-column: unset;
-        grid-row: unset;
+
+      .page-header {
+        background-color: var(--card-bg);
+        border-radius: 12px;
+        padding: 2rem;
+        margin-bottom: 2rem;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+        text-align: center;
       }
-    }
-    
-    .category-card {
-      background: var(--card-bg);
-      padding: 2rem 1.5rem;
-      border-radius: 8px;
-      border: 1px solid var(--border-color);
-      text-align: center;
-      transition: transform 0.2s ease, box-shadow 0.2s ease;
-      position: relative;
-      overflow: hidden;
-    }
-    
-    .category-card::before {
-      content: '';
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      height: 4px;
-      background: linear-gradient(90deg, var(--primary-color), var(--accent-color));
-    }
-    
-    .category-card:hover {
-      transform: translateY(-3px);
-      box-shadow: 0 8px 25px rgba(0, 0, 0, 0.12);
-    }
-    
-    .category-score {
-      font-size: 3rem;
-      font-weight: 700;
-      color: var(--primary-color);
-      margin-bottom: 0.75rem;
-      text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
-    }
-    
-    .category-name {
-      font-size: 1.2rem;
-      font-weight: 600;
-      color: var(--text-primary);
-      margin-bottom: 0.75rem;
-      line-height: 1.3;
-    }
-    
-    .category-description {
-      font-size: 0.95rem;
-      color: var(--text-secondary);
-      margin-bottom: 1.25rem;
-      line-height: 1.5;
-      font-weight: 500;
-    }
-    
-    .category-importance {
-      font-size: 0.9rem;
-      color: var(--text-secondary);
-      font-style: italic;
-      line-height: 1.4;
-      padding-top: 0.75rem;
-      border-top: 1px solid var(--border-color);
-      opacity: 0.9;
-    }
-    
-    @media (max-width: 768px) {
+
       .page-title {
-        font-size: 2rem;
+        font-size: 2.5rem;
+        color: var(--primary-color);
+        margin-bottom: 1rem;
+        font-weight: 600;
       }
-      
-      .two-column,
-      .performance-columns {
-        grid-template-columns: 1fr;
-        gap: 2rem;
+
+      .page-subtitle {
+        color: var(--text-secondary);
+        font-size: 1.1rem;
+        margin: 0 auto 2rem;
+        line-height: 1.6;
+        max-width: 900px;
       }
-      
-      .category-grid {
-        grid-template-columns: 1fr;
+
+      .cta-buttons {
+        display: flex;
+        gap: 1rem;
+        justify-content: center;
+        flex-wrap: wrap;
+      }
+
+      .cta-button {
+        padding: 1rem 2rem;
+        border-radius: 8px;
+        text-decoration: none;
+        font-weight: 600;
+        transition: all 0.3s ease;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      .cta-button.primary {
+        background: var(--primary-color);
+        color: white;
+      }
+
+      .cta-button.secondary {
+        background: var(--card-bg);
+        color: var(--text-primary);
+        border: 1px solid var(--border-color);
+      }
+
+      .cta-button:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 8px 25px rgba(0, 0, 0, 0.2);
+      }
+
+      .stats-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
         gap: 1.5rem;
       }
-      
-      .category-score {
+
+      .stat-card {
+        background: var(--card-bg);
+        padding: 1.5rem;
+        border-radius: 8px;
+        border: 1px solid var(--border-color);
+        text-align: center;
+        transition:
+          transform 0.2s ease,
+          box-shadow 0.2s ease;
+      }
+
+      .stat-card:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 6px 20px rgba(0, 0, 0, 0.1);
+      }
+
+      .stat-value {
         font-size: 2.5rem;
+        font-weight: 700;
+        color: var(--primary-color);
+        margin-bottom: 0.5rem;
       }
-      
-      .cta-buttons {
-        flex-direction: column;
-        align-items: center;
-        padding: 0 1rem;
-        width: 100%;
-        box-sizing: border-box;
-      }
-      
-      .cta-button {
-        width: 100%;
-        max-width: 280px;
-        justify-content: center;
-        padding: 0.875rem 1.5rem;
-        font-size: 0.95rem;
-        box-sizing: border-box;
-      }
-      
-      .page-header {
-        padding: 1.5rem 1rem;
-        margin: 0 0.5rem 1.5rem 0.5rem;
-      }
-      
-      .page-title {
-        font-size: 1.5rem;
-      }
-      
-      .page-subtitle {
-        font-size: 0.95rem;
-        margin-bottom: 1.5rem;
-      }
-    }
-    
-    @media (max-width: 400px) {
-      .page-header {
-        margin: 0 0.25rem 1rem 0.25rem;
-        padding: 1rem 0.75rem;
-      }
-      
-      .cta-button {
-        padding: 0.75rem 1rem;
+
+      .stat-label {
+        color: var(--text-secondary);
         font-size: 0.9rem;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
       }
-      
-      .page-title {
-        font-size: 1.3rem;
+
+      /* Date range styling */
+      .date-separator {
+        color: #ccc;
+        margin: 0 0.5rem;
+        font-weight: 300;
+        font-size: 0.9em;
       }
-    }
-  </style>
-</head>
-<body>
-  <!-- Skip Link for Accessibility -->
-  <a href="#main-content" class="skip-link">Skip to main content</a>
-  
-  <!-- Navigation Bar -->
-  <nav class="navbar" role="navigation" aria-label="Main Navigation">
-    <img src="assets/logo.svg" alt="CNA Scorecard Logo" class="navbar-logo">
-    <div class="navbar-links">
-      <a href="index.html" class="active">Home</a>
-      <a href="cna/index.html">CNAs</a>
-      <a href="completeness/index.html">Record Completeness</a>
-      <a href="trends.html">Performance Trends</a>
-      <a href="scoring.html">Methodology</a>
-    </div>
-  </nav>
 
-  <main class="container" id="main-content">
-    <!-- Page Header -->
-    <section class="page-header">
-      <h1 class="page-title">CNA Scorecard: Tracking CVE Data Completeness</h1>
-      <p class="page-subtitle">
-        Tracks how thoroughly CVE Numbering Authorities populate vulnerability records with actionable intelligence over the last 6 months, 
-        helping users of their products better understand, prioritize, and respond to security threats.
-      </p>
-      <div class="cta-buttons">
-        <a href="cna/index.html" class="cta-button primary">Explore CNA Scores</a>
-        <a href="completeness/index.html" class="cta-button secondary">View Completeness Report</a>
-      </div>
-    </section>
-
-    <!-- Category Breakdown Section -->
-    <section class="section">
-      <h2 class="section-title">Understanding CVE Data Completeness: Five Key Categories</h2>
-      <p style="color: var(--text-secondary); line-height: 1.6; font-size: 1.1rem; text-align: center; max-width: 1000px; margin: 0 auto 3rem;">
-        Complete data in vulnerability records helps security teams make informed decisions and respond effectively to threats. 
-        The CNA Scorecard evaluates how thoroughly CVE Numbering Authorities populate five essential categories over the last 6 months, 
-        with the percentages below showing average completeness scores across all CNAs during this period.
-      </p>
-      <div class="category-grid" id="categoryGrid">
-        <!-- Category cards will be populated by JavaScript -->
-      </div>
-    </section>
-
-    <!-- CNA Performance Snapshot -->
-    <section class="section">
-      <h2 class="section-title">CNA Performance Snapshot</h2>
-      <div class="performance-columns" id="performanceColumns">
-        <!-- Performance columns will be populated by JavaScript -->
-      </div>
-      <div class="centered-cta">
-        <a href="cna/index.html" class="cta-button primary">View Full Leaderboard</a>
-      </div>
-    </section>
-
-    <!-- Key Statistics Section -->
-    <section class="section">
-      <h2 class="section-title">Key Statistics</h2>
-      <div class="stats-grid" id="statsGrid">
-        <!-- Statistics cards will be populated by JavaScript -->
-      </div>
-    </section>
-  </main>
-
-  <!-- Footer -->
-  <footer class="footer">
-    <div class="footer-main">
-      <div class="footer-brand">
-        <img src="assets/logo.svg" alt="CNA Scorecard Logo" class="footer-logo">
-        <span class="footer-title">CNA Scorecard</span>
-      </div>
-      <div class="footer-links">
-        <a href="https://github.com/RogoLabs/CNAScoreCard" target="_blank">GitHub</a>
-        <a href="https://rogolabs.net" target="_blank">RogoLabs</a>
-        <a href="https://patchthis.app" target="_blank">PatchThis</a>
-        <a href="https://cveforecast.org" target="_blank">CVEForecast</a>
-        <a href="https://cve.icu" target="_blank">CVE.ICU</a>
-      </div>
-    </div>
-    <div class="footer-meta">&copy; 2025 RogoLabs. All rights reserved.</div>
-  </footer>
-
-  <!-- JavaScript -->
-  <script type="module">
-    import { createHorizontalBarChart } from './shared/charts.js';
-
-    // Utility function for number formatting
-    function formatNumber(num) {
-      if (num >= 1000000) {
-        return (num / 1000000).toFixed(1) + 'M';
-      } else if (num >= 1000) {
-        return (num / 1000).toFixed(1) + 'K';
+      .date-start,
+      .date-end {
+        display: inline-block;
       }
-      return num.toString();
-    }
 
-    // Utility function for date formatting
-    function formatDateRange(dateRangeString) {
-      try {
-        // Parse the date range string (e.g., "2025-01-23 to 2025-07-23")
-        const parts = dateRangeString.split(' to ');
-        if (parts.length !== 2) return dateRangeString;
-        
-        // Parse as UTC to avoid timezone conversion issues
-        const startDate = new Date(parts[0] + 'T12:00:00Z');
-        const endDate = new Date(parts[1] + 'T12:00:00Z');
-        
-        const formatDate = (date) => {
-          const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-                         'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-          
-          const day = date.getDate();
-          const month = months[date.getMonth()];
-          const year = date.getFullYear();
-          
-          // Add ordinal suffix (st, nd, rd, th)
-          const getOrdinal = (n) => {
-            const s = ['th', 'st', 'nd', 'rd'];
-            const v = n % 100;
-            return n + (s[(v - 20) % 10] || s[v] || s[0]);
+      .section {
+        background-color: var(--card-bg);
+        border-radius: 12px;
+        padding: 2rem;
+        margin-bottom: 2rem;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+      }
+
+      .section-title {
+        font-size: 1.75rem;
+        font-weight: 600;
+        margin-bottom: 1.5rem;
+        text-align: center;
+        color: var(--primary-color);
+      }
+
+      .two-column {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 3rem;
+        align-items: center;
+      }
+
+      .chart-container {
+        background: var(--card-bg);
+        padding: 2rem;
+        border-radius: 12px;
+        border: 1px solid var(--border-color);
+      }
+
+      .chart-canvas {
+        width: 100%;
+        height: 400px;
+      }
+
+      .performance-columns {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 1.5rem;
+      }
+
+      .performance-column {
+        background: var(--card-bg);
+        padding: 1.5rem;
+        border-radius: 8px;
+        border: 1px solid var(--border-color);
+      }
+
+      .performance-column h3 {
+        margin-bottom: 1.5rem;
+        color: var(--text-primary);
+        font-size: 1.25rem;
+      }
+
+      .cna-item {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 0.75rem 0;
+        border-bottom: 1px solid var(--border-color);
+      }
+
+      .cna-item:last-child {
+        border-bottom: none;
+      }
+
+      .cna-name {
+        color: var(--primary-color);
+        text-decoration: none;
+        font-weight: 500;
+      }
+
+      .cna-name:hover {
+        text-decoration: underline;
+      }
+
+      .cna-score {
+        font-weight: 600;
+        color: var(--text-secondary);
+      }
+
+      .centered-cta {
+        text-align: center;
+        margin-top: 2rem;
+      }
+
+      .category-grid {
+        display: grid;
+        grid-template-columns: repeat(6, 1fr);
+        gap: 2rem;
+        margin-top: 2rem;
+      }
+
+      .category-grid .category-card:nth-child(1) {
+        grid-column: 1 / 3;
+      }
+
+      .category-grid .category-card:nth-child(2) {
+        grid-column: 3 / 5;
+      }
+
+      .category-grid .category-card:nth-child(3) {
+        grid-column: 5 / 7;
+      }
+
+      .category-grid .category-card:nth-child(4) {
+        grid-column: 2 / 4;
+        grid-row: 2;
+      }
+
+      .category-grid .category-card:nth-child(5) {
+        grid-column: 4 / 6;
+        grid-row: 2;
+      }
+
+      @media (max-width: 1024px) {
+        .category-grid {
+          grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+        }
+
+        .category-grid .category-card:nth-child(1),
+        .category-grid .category-card:nth-child(2),
+        .category-grid .category-card:nth-child(3),
+        .category-grid .category-card:nth-child(4),
+        .category-grid .category-card:nth-child(5) {
+          grid-column: unset;
+          grid-row: unset;
+        }
+      }
+
+      .category-card {
+        background: var(--card-bg);
+        padding: 2rem 1.5rem;
+        border-radius: 8px;
+        border: 1px solid var(--border-color);
+        text-align: center;
+        transition:
+          transform 0.2s ease,
+          box-shadow 0.2s ease;
+        position: relative;
+        overflow: hidden;
+      }
+
+      .category-card::before {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 4px;
+        background: linear-gradient(
+          90deg,
+          var(--primary-color),
+          var(--accent-color)
+        );
+      }
+
+      .category-card:hover {
+        transform: translateY(-3px);
+        box-shadow: 0 8px 25px rgba(0, 0, 0, 0.12);
+      }
+
+      .category-score {
+        font-size: 3rem;
+        font-weight: 700;
+        color: var(--primary-color);
+        margin-bottom: 0.75rem;
+        text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+      }
+
+      .category-name {
+        font-size: 1.2rem;
+        font-weight: 600;
+        color: var(--text-primary);
+        margin-bottom: 0.75rem;
+        line-height: 1.3;
+      }
+
+      .category-description {
+        font-size: 0.95rem;
+        color: var(--text-secondary);
+        margin-bottom: 1.25rem;
+        line-height: 1.5;
+        font-weight: 500;
+      }
+
+      .category-importance {
+        font-size: 0.9rem;
+        color: var(--text-secondary);
+        font-style: italic;
+        line-height: 1.4;
+        padding-top: 0.75rem;
+        border-top: 1px solid var(--border-color);
+        opacity: 0.9;
+      }
+
+      @media (max-width: 768px) {
+        .page-title {
+          font-size: 2rem;
+        }
+
+        .two-column,
+        .performance-columns {
+          grid-template-columns: 1fr;
+          gap: 2rem;
+        }
+
+        .category-grid {
+          grid-template-columns: 1fr;
+          gap: 1.5rem;
+        }
+
+        .category-score {
+          font-size: 2.5rem;
+        }
+
+        .cta-buttons {
+          flex-direction: column;
+          align-items: center;
+          padding: 0 1rem;
+          width: 100%;
+          box-sizing: border-box;
+        }
+
+        .cta-button {
+          width: 100%;
+          max-width: 280px;
+          justify-content: center;
+          padding: 0.875rem 1.5rem;
+          font-size: 0.95rem;
+          box-sizing: border-box;
+        }
+
+        .page-header {
+          padding: 1.5rem 1rem;
+          margin: 0 0.5rem 1.5rem 0.5rem;
+        }
+
+        .page-title {
+          font-size: 1.5rem;
+        }
+
+        .page-subtitle {
+          font-size: 0.95rem;
+          margin-bottom: 1.5rem;
+        }
+      }
+
+      @media (max-width: 400px) {
+        .page-header {
+          margin: 0 0.25rem 1rem 0.25rem;
+          padding: 1rem 0.75rem;
+        }
+
+        .cta-button {
+          padding: 0.75rem 1rem;
+          font-size: 0.9rem;
+        }
+
+        .page-title {
+          font-size: 1.3rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Skip Link for Accessibility -->
+    <a href="#main-content" class="skip-link">Skip to main content</a>
+
+    <!-- Navigation Bar -->
+    <nav class="navbar" role="navigation" aria-label="Main Navigation">
+      <img src="assets/logo.svg" alt="CNA Scorecard Logo" class="navbar-logo" />
+      <div class="navbar-links">
+        <a href="index.html" class="active">Home</a>
+        <a href="cna/index.html">CNAs</a>
+        <a href="completeness/index.html">Record Completeness</a>
+        <a href="trends.html">Performance Trends</a>
+        <a href="scoring.html">Methodology</a>
+      </div>
+    </nav>
+
+    <main class="container" id="main-content">
+      <!-- Page Header -->
+      <section class="page-header">
+        <h1 class="page-title">
+          CNA Scorecard: Tracking CVE Data Completeness
+        </h1>
+        <p class="page-subtitle">
+          Tracks how thoroughly CVE Numbering Authorities populate vulnerability
+          records with actionable intelligence over the last 6 months, helping
+          users of their products better understand, prioritize, and respond to
+          security threats.
+        </p>
+        <div class="cta-buttons">
+          <a href="cna/index.html" class="cta-button primary"
+            >Explore CNA Scores</a
+          >
+          <a href="completeness/index.html" class="cta-button secondary"
+            >View Completeness Report</a
+          >
+        </div>
+      </section>
+
+      <!-- Category Breakdown Section -->
+      <section class="section">
+        <h2 class="section-title">
+          Understanding CVE Data Completeness: Five Key Categories
+        </h2>
+        <p
+          style="
+            color: var(--text-secondary);
+            line-height: 1.6;
+            font-size: 1.1rem;
+            text-align: center;
+            max-width: 1000px;
+            margin: 0 auto 3rem;
+          "
+        >
+          Complete data in vulnerability records helps security teams make
+          informed decisions and respond effectively to threats. The CNA
+          Scorecard evaluates how thoroughly CVE Numbering Authorities populate
+          five essential categories over the last 6 months, with the percentages
+          below showing average completeness scores across all CNAs during this
+          period.
+        </p>
+        <div class="category-grid" id="categoryGrid">
+          <!-- Category cards will be populated by JavaScript -->
+        </div>
+      </section>
+
+      <!-- CNA Performance Snapshot -->
+      <section class="section">
+        <h2 class="section-title">CNA Performance Snapshot</h2>
+        <div class="performance-columns" id="performanceColumns">
+          <!-- Performance columns will be populated by JavaScript -->
+        </div>
+        <div class="centered-cta">
+          <a href="cna/index.html" class="cta-button primary"
+            >View Full Leaderboard</a
+          >
+        </div>
+      </section>
+
+      <!-- Key Statistics Section -->
+      <section class="section">
+        <h2 class="section-title">Key Statistics</h2>
+        <div class="stats-grid" id="statsGrid">
+          <!-- Statistics cards will be populated by JavaScript -->
+        </div>
+      </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="footer">
+      <div class="footer-main">
+        <div class="footer-brand">
+          <img
+            src="assets/logo.svg"
+            alt="CNA Scorecard Logo"
+            class="footer-logo"
+          />
+          <span class="footer-title">CNA Scorecard</span>
+        </div>
+        <div class="footer-links">
+          <a href="https://github.com/RogoLabs/CNAScoreCard" target="_blank"
+            >GitHub</a
+          >
+          <a href="https://rogolabs.net" target="_blank">RogoLabs</a>
+          <a href="https://patchthis.app" target="_blank">PatchThis</a>
+          <a href="https://cveforecast.org" target="_blank">CVEForecast</a>
+          <a href="https://cve.icu" target="_blank">CVE.ICU</a>
+        </div>
+      </div>
+      <div class="footer-meta">&copy; 2025 RogoLabs. All rights reserved.</div>
+    </footer>
+
+    <!-- JavaScript -->
+    <script type="module">
+      import { createHorizontalBarChart } from "./shared/charts.js";
+
+      // Utility function for number formatting
+      function formatNumber(num) {
+        if (num >= 1000000) {
+          return (num / 1000000).toFixed(1) + "M";
+        } else if (num >= 1000) {
+          return (num / 1000).toFixed(1) + "K";
+        }
+        return num.toString();
+      }
+
+      // Utility function for date formatting
+      function formatDateRange(dateRangeString) {
+        try {
+          // Parse the date range string (e.g., "2025-01-23 to 2025-07-23")
+          const parts = dateRangeString.split(" to ");
+          if (parts.length !== 2) return dateRangeString;
+
+          // Parse as UTC to avoid timezone conversion issues
+          const startDate = new Date(parts[0] + "T12:00:00Z");
+          const endDate = new Date(parts[1] + "T12:00:00Z");
+
+          const formatDate = (date) => {
+            const months = [
+              "Jan",
+              "Feb",
+              "Mar",
+              "Apr",
+              "May",
+              "Jun",
+              "Jul",
+              "Aug",
+              "Sep",
+              "Oct",
+              "Nov",
+              "Dec",
+            ];
+
+            const day = date.getDate();
+            const month = months[date.getMonth()];
+            const year = date.getFullYear();
+
+            // Add ordinal suffix (st, nd, rd, th)
+            const getOrdinal = (n) => {
+              const s = ["th", "st", "nd", "rd"];
+              const v = n % 100;
+              return n + (s[(v - 20) % 10] || s[v] || s[0]);
+            };
+
+            return `${month} ${getOrdinal(day)}, ${year}`;
           };
-          
-          return `${month} ${getOrdinal(day)}, ${year}`;
-        };
-        
-        return `<span class="date-start">${formatDate(startDate)}</span><span class="date-separator">–</span><span class="date-end">${formatDate(endDate)}</span>`;
-      } catch (error) {
-        console.error('Error formatting date range:', error);
-        return dateRangeString; // Return original if formatting fails
+
+          return `<span class="date-start">${formatDate(startDate)}</span><span class="date-separator">–</span><span class="date-end">${formatDate(endDate)}</span>`;
+        } catch (error) {
+          console.error("Error formatting date range:", error);
+          return dateRangeString; // Return original if formatting fails
+        }
       }
-    }
 
-    // Load and display key statistics
-    async function loadKeyStatistics(cnaData, completenessData) {
-      try {
-        // Calculate statistics from the data
-        const totalCNAs = cnaData.length;
-        const totalCVEs = completenessData.total_cves_analyzed || 0;
-        const rawAnalysisPeriod = completenessData.analysis_period || 'Not available';
-        const analysisPeriod = rawAnalysisPeriod !== 'Not available' ? formatDateRange(rawAnalysisPeriod) : rawAnalysisPeriod;
-        
-        // Calculate average overall score from CNAs with valid scores
-        const cnasWithScores = cnaData.filter(cna => cna.scores && cna.scores.overall_average_score > 0);
-        const avgScore = cnasWithScores.length > 0 
-          ? (cnasWithScores.reduce((sum, cna) => sum + cna.scores.overall_average_score, 0) / cnasWithScores.length).toFixed(1)
-          : '0.0';
-        
-        // Calculate active CNAs (CNAs that have contributed recent CVEs)
-        const activeCNAs = cnaData.filter(cna => cna.recent_cves && cna.recent_cves > 0).length;
+      // Load and display key statistics
+      async function loadKeyStatistics(cnaData, completenessData) {
+        try {
+          // Calculate statistics from the data
+          const totalCNAs = cnaData.length;
+          const totalCVEs = completenessData.total_cves_analyzed || 0;
+          const rawAnalysisPeriod =
+            completenessData.analysis_period || "Not available";
+          const analysisPeriod =
+            rawAnalysisPeriod !== "Not available"
+              ? formatDateRange(rawAnalysisPeriod)
+              : rawAnalysisPeriod;
 
-        const statsGrid = document.getElementById('statsGrid');
-        statsGrid.innerHTML = `
+          // Calculate average overall score from CNAs with valid scores
+          const cnasWithScores = cnaData.filter(
+            (cna) => cna.scores && cna.scores.overall_average_score > 0,
+          );
+          const avgScore =
+            cnasWithScores.length > 0
+              ? (
+                  cnasWithScores.reduce(
+                    (sum, cna) => sum + cna.scores.overall_average_score,
+                    0,
+                  ) / cnasWithScores.length
+                ).toFixed(1)
+              : "0.0";
+
+          // Calculate active CNAs (CNAs that have contributed recent CVEs)
+          const activeCNAs = cnaData.filter(
+            (cna) => cna.recent_cves && cna.recent_cves > 0,
+          ).length;
+
+          const statsGrid = document.getElementById("statsGrid");
+          statsGrid.innerHTML = `
           <div class="stat-card">
             <div class="stat-label">Total CVEs Analyzed</div>
             <div class="stat-value">${formatNumber(totalCVEs)}</div>
@@ -559,64 +632,77 @@
             <div class="stat-value" style="font-size: 1.8rem;">${analysisPeriod}</div>
           </div>
         `;
-      } catch (error) {
-        console.error('Error loading key statistics:', error);
-        document.getElementById('statsGrid').innerHTML = '<p>Error loading statistics</p>';
-      }
-    }
-
-    // Load and display category breakdown
-    async function loadCategoryBreakdown(data) {
-      try {
-        // Filter CNAs with valid scores
-        const cnasWithScores = data.filter(cna => cna.scores && cna.scores.overall_average_score > 0);
-        
-        if (cnasWithScores.length === 0) {
-          document.getElementById('categoryGrid').innerHTML = '<p>No scoring data available</p>';
-          return;
+        } catch (error) {
+          console.error("Error loading key statistics:", error);
+          document.getElementById("statsGrid").innerHTML =
+            "<p>Error loading statistics</p>";
         }
-        
-        // Calculate average scores for each category
-        const categories = [
-          {
-            key: 'foundational_completeness',
-            label: 'Foundational Completeness',
-            description: 'Essential CVE fields like ID, description, and affected products',
-            importance: 'The essential building blocks of every CVE record, required for publication and providing basic context needed to understand any vulnerability'
-          },
-          {
-            key: 'root_cause_analysis', 
-            label: 'Root Cause Analysis',
-            description: 'Common Weakness Enumeration (CWE)',
-            importance: 'Understanding the "why" behind vulnerabilities helps development teams recognize common weakness patterns and implement preventive measures'
-          },
-          {
-            key: 'software_identification',
-            label: 'Software Identification', 
-            description: 'Common Platform Enumeration (CPE)',
-            importance: 'Enabling precise vulnerability detection by allowing security tools to accurately match vulnerabilities to specific software versions'
-          },
-          {
-            key: 'severity_and_impact',
-            label: 'Severity & Impact',
-            description: 'Common Vulnerability Scoring System (CVSS)',
-            importance: 'Supporting informed risk decisions by helping organizations prioritize their response based on potential business impact'
-          },
-          {
-            key: 'patchinfo',
-            label: 'Patch Information',
-            description: 'Links to patches, fixes, or mitigation information',
-            importance: 'Connecting problems to solutions by providing links to patches, fixes, and mitigation guidance for faster remediation'
+      }
+
+      // Load and display category breakdown
+      async function loadCategoryBreakdown(data) {
+        try {
+          // Filter CNAs with valid scores
+          const cnasWithScores = data.filter(
+            (cna) => cna.scores && cna.scores.overall_average_score > 0,
+          );
+
+          if (cnasWithScores.length === 0) {
+            document.getElementById("categoryGrid").innerHTML =
+              "<p>No scoring data available</p>";
+            return;
           }
-        ];
-        
-        // Calculate averages and create cards
-        const categoryCards = categories.map(category => {
-          const average = cnasWithScores.reduce((sum, cna) => {
-            return sum + (cna.scores[category.key] || 0);
-          }, 0) / cnasWithScores.length;
-          
-          return `
+
+          // Calculate average scores for each category
+          const categories = [
+            {
+              key: "foundational_completeness",
+              label: "Foundational Completeness",
+              description:
+                "Essential CVE fields like ID, description, and affected products",
+              importance:
+                "The essential building blocks of every CVE record, required for publication and providing basic context needed to understand any vulnerability",
+            },
+            {
+              key: "root_cause_analysis",
+              label: "Root Cause Analysis",
+              description: "Common Weakness Enumeration (CWE)",
+              importance:
+                'Understanding the "why" behind vulnerabilities helps development teams recognize common weakness patterns and implement preventive measures',
+            },
+            {
+              key: "software_identification",
+              label: "Software Identification",
+              description: "Common Platform Enumeration (CPE)",
+              importance:
+                "Enabling precise vulnerability detection by allowing security tools to accurately match vulnerabilities to specific software versions",
+            },
+            {
+              key: "severity_and_impact",
+              label: "Severity & Impact",
+              description: "Common Vulnerability Scoring System (CVSS)",
+              importance:
+                "Supporting informed risk decisions by helping organizations prioritize their response based on potential business impact",
+            },
+            {
+              key: "patchinfo",
+              label: "Patch Information",
+              description:
+                "References tagged with the patch tag in the CVE record",
+              importance:
+                "The patch tag is the clearest structured signal that a specific fix is available, enabling security teams and automated tools to find remediation quickly",
+            },
+          ];
+
+          // Calculate averages and create cards
+          const categoryCards = categories
+            .map((category) => {
+              const average =
+                cnasWithScores.reduce((sum, cna) => {
+                  return sum + (cna.scores[category.key] || 0);
+                }, 0) / cnasWithScores.length;
+
+              return `
             <div class="category-card">
               <div class="category-score" style="color: var(--primary-color)">${average.toFixed(1)}%</div>
               <div class="category-name">${category.label}</div>
@@ -624,89 +710,108 @@
               <div class="category-importance">${category.importance}</div>
             </div>
           `;
-        }).join('');
-        
-        document.getElementById('categoryGrid').innerHTML = categoryCards;
-        
-      } catch (error) {
-        console.error('Error loading category breakdown data:', error);
-        document.getElementById('categoryGrid').innerHTML = '<p>Error loading category data</p>';
-      }
-    }
+            })
+            .join("");
 
-    // Load and display CNA performance snapshot
-    async function loadCNAPerformanceSnapshot(data) {
-      try {
-        // Filter CNAs with valid scores and sort by overall average score
-        const validCNAs = data
-          .filter(cna => cna.scores && cna.scores.overall_average_score > 0)
-          .sort((a, b) => b.scores.overall_average_score - a.scores.overall_average_score);
-        
-        const top5 = validCNAs.slice(0, 5);
-        
-        // Find most active CNAs (highest recent CVE count) that aren't in top 5
-        const mostActive = data
-          .filter(cna => cna.scores && cna.scores.overall_average_score > 0 && 
-                        cna.recent_cves && cna.recent_cves > 0 &&
-                        !top5.some(top => top.shortName === cna.shortName))
-          .sort((a, b) => b.recent_cves - a.recent_cves)
-          .slice(0, 5);
-        
-        const performanceColumns = document.getElementById('performanceColumns');
-        performanceColumns.innerHTML = `
+          document.getElementById("categoryGrid").innerHTML = categoryCards;
+        } catch (error) {
+          console.error("Error loading category breakdown data:", error);
+          document.getElementById("categoryGrid").innerHTML =
+            "<p>Error loading category data</p>";
+        }
+      }
+
+      // Load and display CNA performance snapshot
+      async function loadCNAPerformanceSnapshot(data) {
+        try {
+          // Filter CNAs with valid scores and sort by overall average score
+          const validCNAs = data
+            .filter((cna) => cna.scores && cna.scores.overall_average_score > 0)
+            .sort(
+              (a, b) =>
+                b.scores.overall_average_score - a.scores.overall_average_score,
+            );
+
+          const top5 = validCNAs.slice(0, 5);
+
+          // Find most active CNAs (highest recent CVE count) that aren't in top 5
+          const mostActive = data
+            .filter(
+              (cna) =>
+                cna.scores &&
+                cna.scores.overall_average_score > 0 &&
+                cna.recent_cves &&
+                cna.recent_cves > 0 &&
+                !top5.some((top) => top.shortName === cna.shortName),
+            )
+            .sort((a, b) => b.recent_cves - a.recent_cves)
+            .slice(0, 5);
+
+          const performanceColumns =
+            document.getElementById("performanceColumns");
+          performanceColumns.innerHTML = `
           <div class="performance-column">
             <h3>Top 5 Scoring CNAs</h3>
-            ${top5.map(cna => `
+            ${top5
+              .map(
+                (cna) => `
               <div class="cna-item">
                 <a href="cna/cna-detail.html?shortName=${encodeURIComponent(cna.shortName)}" class="cna-name">
                   ${cna.shortName}
                 </a>
                 <span class="cna-score">${cna.scores.overall_average_score.toFixed(1)}%</span>
               </div>
-            `).join('')}
+            `,
+              )
+              .join("")}
           </div>
           <div class="performance-column">
             <h3>Most Active CNAs</h3>
-            ${mostActive.map(cna => `
+            ${mostActive
+              .map(
+                (cna) => `
               <div class="cna-item">
                 <a href="cna/cna-detail.html?shortName=${encodeURIComponent(cna.shortName)}" class="cna-name">
                   ${cna.shortName}
                 </a>
                 <span class="cna-score">${cna.recent_cves} CVEs</span>
               </div>
-            `).join('')}
+            `,
+              )
+              .join("")}
           </div>
         `;
-      } catch (error) {
-        console.error('Error loading CNA performance data:', error);
-        document.getElementById('performanceColumns').innerHTML = '<p>Error loading performance data</p>';
+        } catch (error) {
+          console.error("Error loading CNA performance data:", error);
+          document.getElementById("performanceColumns").innerHTML =
+            "<p>Error loading performance data</p>";
+        }
       }
-    }
 
-    // Initialize the homepage
-    async function initializeHomepage() {
-      // Fetch shared data once and pass to all sections
-      const [cnaResponse, completenessResponse] = await Promise.all([
-        fetch('./data/cna_combined.json'),
-        fetch('./data/completeness_summary.json')
-      ]);
+      // Initialize the homepage
+      async function initializeHomepage() {
+        // Fetch shared data once and pass to all sections
+        const [cnaResponse, completenessResponse] = await Promise.all([
+          fetch("./data/cna_combined.json"),
+          fetch("./data/completeness_summary.json"),
+        ]);
 
-      const [cnaData, completenessData] = await Promise.all([
-        cnaResponse.json(),
-        completenessResponse.json()
-      ]);
+        const [cnaData, completenessData] = await Promise.all([
+          cnaResponse.json(),
+          completenessResponse.json(),
+        ]);
 
-      await Promise.all([
-        loadKeyStatistics(cnaData, completenessData),
-        loadCategoryBreakdown(cnaData),
-        loadCNAPerformanceSnapshot(cnaData)
-      ]);
-    }
+        await Promise.all([
+          loadKeyStatistics(cnaData, completenessData),
+          loadCategoryBreakdown(cnaData),
+          loadCNAPerformanceSnapshot(cnaData),
+        ]);
+      }
 
-    // Load everything when the DOM is ready
-    document.addEventListener('DOMContentLoaded', initializeHomepage);
-  </script>
-  <script src="shared/utils.js"></script>
-  <script src="shared/mobile-nav.js"></script>
-</body>
+      // Load everything when the DOM is ready
+      document.addEventListener("DOMContentLoaded", initializeHomepage);
+    </script>
+    <script src="shared/utils.js"></script>
+    <script src="shared/mobile-nav.js"></script>
+  </body>
 </html>

--- a/web/scoring.html
+++ b/web/scoring.html
@@ -1,169 +1,308 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MQJ07VQQQN"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
+  <head>
+    <!-- Google tag (gtag.js) -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-MQJ07VQQQN"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
 
-    gtag('config', 'G-MQJ07VQQQN');
-  </script>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Learn how CNA Scorecard scores CVE records across 5 categories: completeness, root cause, severity, software identification, and patch info.">
-  <link rel="canonical" href="https://cnascorecard.org/scoring.html">
-  <title>CNA Scorecard</title>
-  <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
-  <link rel="icon" type="image/png" href="assets/logo.svg">
-  <link rel="stylesheet" href="assets/theme.css">
-  <link rel="stylesheet" href="shared/shared.css">
-  <link rel="stylesheet" href="scoring.css">
-</head>
-<body>
-  <!-- Skip Link for Accessibility -->
-  <a href="#main-content" class="skip-link">Skip to main content</a>
-  
-  <nav class="navbar" role="navigation" aria-label="Main Navigation">
-    <img src="assets/logo.svg" alt="CNA Scorecard Logo" class="navbar-logo">
-    <div class="navbar-links">
-      <a href="index.html">Home</a>
-      <a href="cna/index.html">CNAs</a>
-      <a href="completeness/index.html">Record Completeness</a>
-      <a href="trends.html">Performance Trends</a>
-      <a href="scoring.html" class="active">Methodology</a>
-    </div>
-  </nav>
-  <main class="container scoring-cards-container" id="main-content">
-    <!-- Introduction Section -->
-    <section class="scoring-summary-card card">
-      <h1 class="scoring-title">Scoring Methodology</h1>
-      <p class="main-description">
-        The CNA Scorecard promotes transparency and accountability in vulnerability reporting by measuring how completely 
-        CVE Numbering Authorities populate essential data fields. The scoring philosophy is simple: complete, actionable 
-        vulnerability data leads to better security outcomes for everyone.
-      </p>
-    </section>
+      gtag("config", "G-MQJ07VQQQN");
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Learn how CNA Scorecard scores CVE records across 5 categories: completeness, root cause, severity, software identification, and patch info."
+    />
+    <link rel="canonical" href="https://cnascorecard.org/scoring.html" />
+    <title>CNA Scorecard</title>
+    <link rel="icon" type="image/svg+xml" href="assets/logo.svg" />
+    <link rel="icon" type="image/png" href="assets/logo.svg" />
+    <link rel="stylesheet" href="assets/theme.css" />
+    <link rel="stylesheet" href="shared/shared.css" />
+    <link rel="stylesheet" href="scoring.css" />
+  </head>
+  <body>
+    <!-- Skip Link for Accessibility -->
+    <a href="#main-content" class="skip-link">Skip to main content</a>
 
-    <!-- Scoring Window Section -->
-    <section class="scoring-window-card card">
-      <h2>Scoring Window</h2>
-      <div class="window-info">
-        <div class="current-period">
-          <h3>Current Analysis Period</h3>
-          <p class="period-dates" id="currentPeriod">Loading...</p>
-          <p class="period-description">
-            All CNA scores are based on CVE records published during this 6-month window. This ensures 
-            scores reflect recent performance and current data quality practices.
+    <nav class="navbar" role="navigation" aria-label="Main Navigation">
+      <img src="assets/logo.svg" alt="CNA Scorecard Logo" class="navbar-logo" />
+      <div class="navbar-links">
+        <a href="index.html">Home</a>
+        <a href="cna/index.html">CNAs</a>
+        <a href="completeness/index.html">Record Completeness</a>
+        <a href="trends.html">Performance Trends</a>
+        <a href="scoring.html" class="active">Methodology</a>
+      </div>
+    </nav>
+    <main class="container scoring-cards-container" id="main-content">
+      <!-- Introduction Section -->
+      <section class="scoring-summary-card card">
+        <h1 class="scoring-title">Scoring Methodology</h1>
+        <p class="main-description">
+          The CNA Scorecard promotes transparency and accountability in
+          vulnerability reporting by measuring how completely CVE Numbering
+          Authorities populate essential data fields. The scoring philosophy is
+          simple: complete, actionable vulnerability data leads to better
+          security outcomes for everyone.
+        </p>
+      </section>
+
+      <!-- Scoring Window Section -->
+      <section class="scoring-window-card card">
+        <h2>Scoring Window</h2>
+        <div class="window-info">
+          <div class="current-period">
+            <h3>Current Analysis Period</h3>
+            <p class="period-dates" id="currentPeriod">Loading...</p>
+            <p class="period-description">
+              All CNA scores are based on CVE records published during this
+              6-month window. This ensures scores reflect recent performance and
+              current data quality practices.
+            </p>
+          </div>
+
+          <div class="window-details">
+            <h3>How the Scoring Window Works</h3>
+            <ul class="window-features">
+              <li>
+                <strong>Rolling 6-Month Window:</strong> The analysis period
+                automatically updates to always cover the most recent 6 months
+                of CVE data.
+              </li>
+              <li>
+                <strong>Fresh Data:</strong> Scores are recalculated regularly
+                using only CVEs published within the current window, ensuring
+                relevance and accuracy.
+              </li>
+              <li>
+                <strong>Trend Analysis:</strong> Performance trends compare the
+                current 6-month period against the previous 6-month period to
+                show improvement or decline.
+              </li>
+              <li>
+                <strong>Fair Comparison:</strong> All CNAs are evaluated using
+                the same time window, creating consistent and comparable scoring
+                across organizations.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <!-- Scoring Categories Section -->
+      <section class="scoring-categories-card card">
+        <h2>Scoring Categories</h2>
+        <p class="categories-intro">
+          The scoring system evaluates CVE records across five essential
+          categories, with points allocated based on the relative importance of
+          each type of information for security decision-making.
+        </p>
+
+        <div class="category-detail">
+          <h3>
+            <span class="category-points">50 points</span> Foundational
+            Completeness
+          </h3>
+          <p class="category-what">
+            <strong>What it is:</strong> The essential building blocks of every
+            CVE record, including problem types, affected products, references,
+            and descriptions.
+          </p>
+          <p class="category-why">
+            <strong>Why it matters:</strong> These are the minimum fields
+            required for CVE publication and provide the basic context needed to
+            understand any vulnerability. Without complete foundational data,
+            security teams cannot properly identify or assess threats.
+          </p>
+          <p class="category-how">
+            <strong>How points are awarded:</strong> Points are earned for
+            including comprehensive problem type classifications, detailed
+            affected product information, relevant reference links, and clear
+            vulnerability descriptions.
           </p>
         </div>
-        
-        <div class="window-details">
-          <h3>How the Scoring Window Works</h3>
-          <ul class="window-features">
-            <li><strong>Rolling 6-Month Window:</strong> The analysis period automatically updates to always cover the most recent 6 months of CVE data.</li>
-            <li><strong>Fresh Data:</strong> Scores are recalculated regularly using only CVEs published within the current window, ensuring relevance and accuracy.</li>
-            <li><strong>Trend Analysis:</strong> Performance trends compare the current 6-month period against the previous 6-month period to show improvement or decline.</li>
-            <li><strong>Fair Comparison:</strong> All CNAs are evaluated using the same time window, creating consistent and comparable scoring across organizations.</li>
-          </ul>
+
+        <div class="category-detail">
+          <h3>
+            <span class="category-points">15 points</span> Root Cause Analysis
+          </h3>
+          <p class="category-what">
+            <strong>What it is:</strong> Information about the underlying
+            weakness that caused the vulnerability, typically expressed as a CWE
+            (Common Weakness Enumeration) identifier.
+          </p>
+          <p class="category-why">
+            <strong>Why it matters:</strong> CWE data helps development teams
+            understand patterns in security flaws and implement preventive
+            measures. It's like knowing that a house fire was caused by faulty
+            wiring versus a gas leak—the root cause determines the best
+            prevention strategy.
+          </p>
+          <p class="category-how">
+            <strong>How points are awarded:</strong> Points are earned for
+            including valid CWE identifiers that accurately describe the
+            specific type of weakness, rather than generic classifications.
+          </p>
         </div>
-      </div>
-    </section>
 
-    <!-- Scoring Categories Section -->
-    <section class="scoring-categories-card card">
-      <h2>Scoring Categories</h2>
-      <p class="categories-intro">
-        The scoring system evaluates CVE records across five essential categories, with points allocated based on 
-        the relative importance of each type of information for security decision-making.
-      </p>
-      
-      <div class="category-detail">
-        <h3><span class="category-points">50 points</span> Foundational Completeness</h3>
-        <p class="category-what"><strong>What it is:</strong> The essential building blocks of every CVE record, including problem types, affected products, references, and descriptions.</p>
-        <p class="category-why"><strong>Why it matters:</strong> These are the minimum fields required for CVE publication and provide the basic context needed to understand any vulnerability. Without complete foundational data, security teams cannot properly identify or assess threats.</p>
-        <p class="category-how"><strong>How points are awarded:</strong> Points are earned for including comprehensive problem type classifications, detailed affected product information, relevant reference links, and clear vulnerability descriptions.</p>
-      </div>
+        <div class="category-detail">
+          <h3>
+            <span class="category-points">15 points</span> Severity & Impact
+            Context
+          </h3>
+          <p class="category-what">
+            <strong>What it is:</strong> Standardized severity ratings using
+            CVSS (Common Vulnerability Scoring System) metrics, which provide
+            numerical scores from 0-10 indicating how serious a vulnerability
+            is.
+          </p>
+          <p class="category-why">
+            <strong>Why it matters:</strong> CVSS scores help organizations
+            prioritize which vulnerabilities to fix first based on potential
+            impact. A CVSS score of 9.8 demands immediate attention, while a 3.1
+            might be scheduled for routine patching.
+          </p>
+          <p class="category-how">
+            <strong>How points are awarded:</strong> Points are earned for
+            including complete CVSS v3 or v4 metrics with valid vector strings
+            that accurately reflect the vulnerability's exploitability and
+            impact.
+          </p>
+        </div>
 
-      <div class="category-detail">
-        <h3><span class="category-points">15 points</span> Root Cause Analysis</h3>
-        <p class="category-what"><strong>What it is:</strong> Information about the underlying weakness that caused the vulnerability, typically expressed as a CWE (Common Weakness Enumeration) identifier.</p>
-        <p class="category-why"><strong>Why it matters:</strong> CWE data helps development teams understand patterns in security flaws and implement preventive measures. It's like knowing that a house fire was caused by faulty wiring versus a gas leak—the root cause determines the best prevention strategy.</p>
-        <p class="category-how"><strong>How points are awarded:</strong> Points are earned for including valid CWE identifiers that accurately describe the specific type of weakness, rather than generic classifications.</p>
-      </div>
+        <div class="category-detail">
+          <h3>
+            <span class="category-points">10 points</span> Software
+            Identification
+          </h3>
+          <p class="category-what">
+            <strong>What it is:</strong> Precise identification of affected
+            software using CPE (Common Platform Enumeration) format, which
+            provides standardized names for software products and versions. CPE
+            data can be provided in either the traditional
+            <code>affected[].cpes</code> field or the advanced CVE 5.1
+            <code>cpeApplicability</code> field.
+          </p>
+          <p class="category-why">
+            <strong>Why it matters:</strong> CPE data enables automated
+            vulnerability scanners to accurately match vulnerabilities to
+            specific software in an organization's environment. Without it,
+            security tools can't reliably identify what's at risk.
+          </p>
+          <p class="category-how">
+            <strong>How points are awarded:</strong> Points are earned for
+            including valid CPE identifiers that precisely specify the affected
+            software products, versions, and configurations. Both traditional
+            CPE lists and advanced applicability statements with version ranges
+            are recognized.
+          </p>
+        </div>
 
-      <div class="category-detail">
-        <h3><span class="category-points">15 points</span> Severity & Impact Context</h3>
-        <p class="category-what"><strong>What it is:</strong> Standardized severity ratings using CVSS (Common Vulnerability Scoring System) metrics, which provide numerical scores from 0-10 indicating how serious a vulnerability is.</p>
-        <p class="category-why"><strong>Why it matters:</strong> CVSS scores help organizations prioritize which vulnerabilities to fix first based on potential impact. A CVSS score of 9.8 demands immediate attention, while a 3.1 might be scheduled for routine patching.</p>
-        <p class="category-how"><strong>How points are awarded:</strong> Points are earned for including complete CVSS v3 or v4 metrics with valid vector strings that accurately reflect the vulnerability's exploitability and impact.</p>
-      </div>
+        <div class="category-detail">
+          <h3>
+            <span class="category-points">10 points</span> Patch Information
+          </h3>
+          <p class="category-what">
+            <strong>What it is:</strong> References tagged with
+            <code>patch</code> in the CVE record, indicating a direct link to a
+            fix for the vulnerability.
+          </p>
+          <p class="category-why">
+            <strong>Why it matters:</strong> Patch information bridges the gap
+            between identifying a vulnerability and actually fixing it. The
+            <code>patch</code> tag is the clearest structured signal that a
+            specific fix is available, making it easy for security teams and
+            automated tools to find remediation quickly.
+          </p>
+          <p class="category-how">
+            <strong>How points are awarded:</strong> Points are earned when at
+            least one reference in the CVE record includes the
+            <code>patch</code> tag. Other reference tags such as
+            <code>vendor-advisory</code> are not currently counted, as they may
+            not always indicate a specific fix is available.
+          </p>
+        </div>
+      </section>
 
-      <div class="category-detail">
-        <h3><span class="category-points">10 points</span> Software Identification</h3>
-        <p class="category-what"><strong>What it is:</strong> Precise identification of affected software using CPE (Common Platform Enumeration) format, which provides standardized names for software products and versions. CPE data can be provided in either the traditional <code>affected[].cpes</code> field or the advanced CVE 5.1 <code>cpeApplicability</code> field.</p>
-        <p class="category-why"><strong>Why it matters:</strong> CPE data enables automated vulnerability scanners to accurately match vulnerabilities to specific software in an organization's environment. Without it, security tools can't reliably identify what's at risk.</p>
-        <p class="category-how"><strong>How points are awarded:</strong> Points are earned for including valid CPE identifiers that precisely specify the affected software products, versions, and configurations. Both traditional CPE lists and advanced applicability statements with version ranges are recognized.</p>
-      </div>
+      <!-- Technical Documentation Section -->
+      <section class="technical-docs-card card" id="technical-documentation">
+        <h2>Technical Documentation for CNAs</h2>
+        <p class="tech-intro">
+          This section provides the exact technical implementation details for
+          CNAs who want to verify the scoring methodology. All field paths
+          reference the official CVE JSON 5.0 schema.
+        </p>
 
-      <div class="category-detail">
-        <h3><span class="category-points">10 points</span> Patch Information</h3>
-        <p class="category-what"><strong>What it is:</strong> Direct links to patches, fixes, or official vendor advisories that provide remediation guidance.</p>
-        <p class="category-why"><strong>Why it matters:</strong> Patch information bridges the gap between identifying a vulnerability and actually fixing it. Security teams need clear paths to remediation, not just problem descriptions.</p>
-        <p class="category-how"><strong>How points are awarded:</strong> Points are earned for including direct links to official patches or vendor advisories, rather than generic references or third-party discussions.</p>
-      </div>
-    </section>
+        <div class="tech-toggle-container">
+          <button class="btn btn-primary" id="toggleTechnicalDetails">
+            Show Technical Details
+          </button>
+        </div>
 
-    <!-- Technical Documentation Section -->
-    <section class="technical-docs-card card" id="technical-documentation">
-      <h2>Technical Documentation for CNAs</h2>
-      <p class="tech-intro">
-        This section provides the exact technical implementation details for CNAs who want to verify 
-        the scoring methodology. All field paths reference the official CVE JSON 5.0 schema.
-      </p>
-      
-      <div class="tech-toggle-container">
-        <button class="btn btn-primary" id="toggleTechnicalDetails">Show Technical Details</button>
-      </div>
-      
-      <div class="technical-details" id="technicalDetails" style="display: none;">
-        
-        <!-- Foundational Completeness Technical Details -->
-        <div class="tech-category" id="foundational-completeness-tech">
-          <h3><span class="category-points">50 points</span> Foundational Completeness - Technical Implementation</h3>
-          
-          <div class="tech-subsection">
-            <h4>Schema Field Paths Checked:</h4>
-            <div class="code-block">
-              <code>containers.cna.descriptions</code> (array)<br>
-              <code>containers.cna.affected</code> (array)<br>
-              <code>containers.cna.references</code> (array)
+        <div
+          class="technical-details"
+          id="technicalDetails"
+          style="display: none"
+        >
+          <!-- Foundational Completeness Technical Details -->
+          <div class="tech-category" id="foundational-completeness-tech">
+            <h3>
+              <span class="category-points">50 points</span> Foundational
+              Completeness - Technical Implementation
+            </h3>
+
+            <div class="tech-subsection">
+              <h4>Schema Field Paths Checked:</h4>
+              <div class="code-block">
+                <code>containers.cna.descriptions</code> (array)<br />
+                <code>containers.cna.affected</code> (array)<br />
+                <code>containers.cna.references</code> (array)
+              </div>
             </div>
-          </div>
-          
-          <div class="tech-subsection">
-            <h4>Validation Logic:</h4>
-            <div class="validation-rule">
-              <strong>Binary Scoring:</strong> All-or-nothing - either 50 points or 0 points
+
+            <div class="tech-subsection">
+              <h4>Validation Logic:</h4>
+              <div class="validation-rule">
+                <strong>Binary Scoring:</strong> All-or-nothing - either 50
+                points or 0 points
+              </div>
+              <div class="validation-rule">
+                <strong>Requirements:</strong> All three field arrays must exist
+                AND contain at least one valid entry
+              </div>
+              <div class="validation-rule">
+                <strong>Validation Criteria:</strong>
+                <ul>
+                  <li>
+                    <code>descriptions</code>: Must be non-empty array with at
+                    least one description object
+                  </li>
+                  <li>
+                    <code>affected</code>: Must be non-empty array with at least
+                    one affected product object
+                  </li>
+                  <li>
+                    <code>references</code>: Must be non-empty array with at
+                    least one reference object
+                  </li>
+                </ul>
+              </div>
             </div>
-            <div class="validation-rule">
-              <strong>Requirements:</strong> All three field arrays must exist AND contain at least one valid entry
-            </div>
-            <div class="validation-rule">
-              <strong>Validation Criteria:</strong>
-              <ul>
-                <li><code>descriptions</code>: Must be non-empty array with at least one description object</li>
-                <li><code>affected</code>: Must be non-empty array with at least one affected product object</li>
-                <li><code>references</code>: Must be non-empty array with at least one reference object</li>
-              </ul>
-            </div>
-          </div>
-          
-          <div class="tech-subsection">
-            <h4>Code Implementation:</h4>
-            <div class="code-block">
-<pre>def _calculate_foundational_completeness(cve, cna):
+
+            <div class="tech-subsection">
+              <h4>Code Implementation:</h4>
+              <div class="code-block">
+                <pre>
+def _calculate_foundational_completeness(cve, cna):
     descriptions = cna.get('descriptions', [])
     affected = cna.get('affected', [])
     references = cna.get('references', [])
@@ -172,42 +311,51 @@
     has_affected = isinstance(affected, list) and len(affected) > 0
     has_references = isinstance(references, list) and len(references) > 0
     
-    return 50 if (has_descriptions and has_affected and has_references) else 0</pre>
+    return 50 if (has_descriptions and has_affected and has_references) else 0</pre
+                >
+              </div>
             </div>
           </div>
-        </div>
-        
-        <!-- Root Cause Analysis Technical Details -->
-        <div class="tech-category" id="root-cause-analysis-tech">
-          <h3><span class="category-points">15 points</span> Root Cause Analysis - Technical Implementation</h3>
-          
-          <div class="tech-subsection">
-            <h4>Schema Field Paths Checked:</h4>
-            <div class="code-block">
-              <code>containers.cna.problemTypes[].descriptions[].cweId</code> (string)
+
+          <!-- Root Cause Analysis Technical Details -->
+          <div class="tech-category" id="root-cause-analysis-tech">
+            <h3>
+              <span class="category-points">15 points</span> Root Cause Analysis
+              - Technical Implementation
+            </h3>
+
+            <div class="tech-subsection">
+              <h4>Schema Field Paths Checked:</h4>
+              <div class="code-block">
+                <code>containers.cna.problemTypes[].descriptions[].cweId</code>
+                (string)
+              </div>
             </div>
-          </div>
-          
-          <div class="tech-subsection">
-            <h4>Validation Logic:</h4>
-            <div class="validation-rule">
-              <strong>Binary Scoring:</strong> Either 15 points or 0 points
+
+            <div class="tech-subsection">
+              <h4>Validation Logic:</h4>
+              <div class="validation-rule">
+                <strong>Binary Scoring:</strong> Either 15 points or 0 points
+              </div>
+              <div class="validation-rule">
+                <strong>CWE ID Format:</strong> Must match pattern
+                <code>CWE-[0-9]+</code> (case-insensitive)
+              </div>
+              <div class="validation-rule">
+                <strong>Valid CWE List:</strong> Must exist in official MITRE
+                CWE database (loaded from cwe_ids.json)
+              </div>
+              <div class="validation-rule">
+                <strong>Search Process:</strong> Iterates through all
+                problemTypes → descriptions → cweId fields
+              </div>
             </div>
-            <div class="validation-rule">
-              <strong>CWE ID Format:</strong> Must match pattern <code>CWE-[0-9]+</code> (case-insensitive)
-            </div>
-            <div class="validation-rule">
-              <strong>Valid CWE List:</strong> Must exist in official MITRE CWE database (loaded from cwe_ids.json)
-            </div>
-            <div class="validation-rule">
-              <strong>Search Process:</strong> Iterates through all problemTypes → descriptions → cweId fields
-            </div>
-          </div>
-          
-          <div class="tech-subsection">
-            <h4>Code Implementation:</h4>
-            <div class="code-block">
-<pre>def _calculate_root_cause_analysis(cve, cna):
+
+            <div class="tech-subsection">
+              <h4>Code Implementation:</h4>
+              <div class="code-block">
+                <pre>
+def _calculate_root_cause_analysis(cve, cna):
     problem_types = cna.get('problemTypes', [])
     if not isinstance(problem_types, list):
         return 0
@@ -234,44 +382,52 @@ def _is_valid_cwe_id(cwe_raw):
         return False
     
     # Check against official CWE database
-    return cwe_raw.upper() in scoring_config.valid_cwe_ids</pre>
+    return cwe_raw.upper() in scoring_config.valid_cwe_ids</pre
+                >
+              </div>
             </div>
           </div>
-        </div>
-        
-        <!-- Severity & Impact Context Technical Details -->
-        <div class="tech-category" id="severity-impact-context-tech">
-          <h3><span class="category-points">15 points</span> Severity & Impact Context - Technical Implementation</h3>
-          
-          <div class="tech-subsection">
-            <h4>Schema Field Paths Checked:</h4>
-            <div class="code-block">
-              <code>containers.cna.metrics[].cvssV3_0</code> (object)<br>
-              <code>containers.cna.metrics[].cvssV3_1</code> (object)<br>
-              <code>containers.cna.metrics[].cvssV4_0</code> (object)
+
+          <!-- Severity & Impact Context Technical Details -->
+          <div class="tech-category" id="severity-impact-context-tech">
+            <h3>
+              <span class="category-points">15 points</span> Severity & Impact
+              Context - Technical Implementation
+            </h3>
+
+            <div class="tech-subsection">
+              <h4>Schema Field Paths Checked:</h4>
+              <div class="code-block">
+                <code>containers.cna.metrics[].cvssV3_0</code> (object)<br />
+                <code>containers.cna.metrics[].cvssV3_1</code> (object)<br />
+                <code>containers.cna.metrics[].cvssV4_0</code> (object)
+              </div>
             </div>
-          </div>
-          
-          <div class="tech-subsection">
-            <h4>Validation Logic:</h4>
-            <div class="validation-rule">
-              <strong>Binary Scoring:</strong> Either 15 points or 0 points
+
+            <div class="tech-subsection">
+              <h4>Validation Logic:</h4>
+              <div class="validation-rule">
+                <strong>Binary Scoring:</strong> Either 15 points or 0 points
+              </div>
+              <div class="validation-rule">
+                <strong>CVSS Version Support:</strong> Accepts CVSS v3.0, v3.1,
+                or v4.0
+              </div>
+              <div class="validation-rule">
+                <strong>Vector String Required:</strong> Must contain valid
+                <code>vectorString</code> field
+              </div>
+              <div class="validation-rule">
+                <strong>Search Process:</strong> Iterates through metrics array
+                looking for any valid CVSS object
+              </div>
             </div>
-            <div class="validation-rule">
-              <strong>CVSS Version Support:</strong> Accepts CVSS v3.0, v3.1, or v4.0
-            </div>
-            <div class="validation-rule">
-              <strong>Vector String Required:</strong> Must contain valid <code>vectorString</code> field
-            </div>
-            <div class="validation-rule">
-              <strong>Search Process:</strong> Iterates through metrics array looking for any valid CVSS object
-            </div>
-          </div>
-          
-          <div class="tech-subsection">
-            <h4>Code Implementation:</h4>
-            <div class="code-block">
-<pre>def _calculate_severity_context(cve, cna):
+
+            <div class="tech-subsection">
+              <h4>Code Implementation:</h4>
+              <div class="code-block">
+                <pre>
+def _calculate_severity_context(cve, cna):
     metrics = cna.get('metrics', [])
     if not isinstance(metrics, list):
         return 0
@@ -294,49 +450,69 @@ def _has_valid_cvss_vector(metrics):
                 cvss_data = metric[version]
                 if isinstance(cvss_data, dict) and cvss_data.get('vectorString'):
                     return True
-    return False</pre>
+    return False</pre
+                >
+              </div>
             </div>
           </div>
-        </div>
-        
-        <!-- Software Identification Technical Details -->
-        <div class="tech-category" id="software-identification-tech">
-          <h3><span class="category-points">10 points</span> Software Identification - Technical Implementation</h3>
-          
-          <div class="tech-subsection">
-            <h4>Schema Field Paths Checked:</h4>
-            <div class="code-block">
-              <strong>Traditional Field:</strong><br>
-              <code>containers.cna.affected[].cpes</code> (array of CPE 2.3 strings)<br>
-              <br>
-              <strong>CVE 5.1 Advanced Field:</strong><br>
-              <code>containers.cna.cpeApplicability[].nodes[].cpeMatch[].criteria</code> (CPE with operators)
+
+          <!-- Software Identification Technical Details -->
+          <div class="tech-category" id="software-identification-tech">
+            <h3>
+              <span class="category-points">10 points</span> Software
+              Identification - Technical Implementation
+            </h3>
+
+            <div class="tech-subsection">
+              <h4>Schema Field Paths Checked:</h4>
+              <div class="code-block">
+                <strong>Traditional Field:</strong><br />
+                <code>containers.cna.affected[].cpes</code> (array of CPE 2.3
+                strings)<br />
+                <br />
+                <strong>CVE 5.1 Advanced Field:</strong><br />
+                <code
+                  >containers.cna.cpeApplicability[].nodes[].cpeMatch[].criteria</code
+                >
+                (CPE with operators)
+              </div>
+              <p
+                style="
+                  margin-top: 1rem;
+                  color: var(--text-secondary);
+                  font-style: italic;
+                "
+              >
+                <strong>Note:</strong> Both field types are checked. Points are
+                awarded if CPE data is found in either location.
+              </p>
             </div>
-            <p style="margin-top: 1rem; color: var(--text-secondary); font-style: italic;">
-              <strong>Note:</strong> Both field types are checked. Points are awarded if CPE data is found in either location.
-            </p>
-          </div>
-          
-          <div class="tech-subsection">
-            <h4>Validation Logic:</h4>
-            <div class="validation-rule">
-              <strong>Binary Scoring:</strong> Either 10 points or 0 points
+
+            <div class="tech-subsection">
+              <h4>Validation Logic:</h4>
+              <div class="validation-rule">
+                <strong>Binary Scoring:</strong> Either 10 points or 0 points
+              </div>
+              <div class="validation-rule">
+                <strong>Dual Field Support:</strong> Checks traditional
+                <code>affected[].cpes</code> first, then CVE 5.1
+                <code>cpeApplicability</code>
+              </div>
+              <div class="validation-rule">
+                <strong>Traditional CPE:</strong> At least one affected product
+                must contain non-empty cpes array
+              </div>
+              <div class="validation-rule">
+                <strong>CPE Applicability:</strong> Must contain valid nodes
+                with cpeMatch entries and criteria strings
+              </div>
             </div>
-            <div class="validation-rule">
-              <strong>Dual Field Support:</strong> Checks traditional <code>affected[].cpes</code> first, then CVE 5.1 <code>cpeApplicability</code>
-            </div>
-            <div class="validation-rule">
-              <strong>Traditional CPE:</strong> At least one affected product must contain non-empty cpes array
-            </div>
-            <div class="validation-rule">
-              <strong>CPE Applicability:</strong> Must contain valid nodes with cpeMatch entries and criteria strings
-            </div>
-          </div>
-          
-          <div class="tech-subsection">
-            <h4>Code Implementation:</h4>
-            <div class="code-block">
-<pre>def _calculate_software_identification(cve, cna):
+
+            <div class="tech-subsection">
+              <h4>Code Implementation:</h4>
+              <div class="code-block">
+                <pre>
+def _calculate_software_identification(cve, cna):
     # Check traditional affected[].cpes field
     affected = cna.get('affected', [])
     if isinstance(affected, list):
@@ -375,14 +551,16 @@ def _has_cpe_applicability(cna):
                 if isinstance(match, dict) and match.get('criteria'):
                     return True
     
-    return False</pre>
+    return False</pre
+                >
+              </div>
             </div>
-          </div>
-          
-          <div class="tech-subsection">
-            <h4>CVE 5.1 cpeApplicability Structure:</h4>
-            <div class="code-block">
-<pre>{
+
+            <div class="tech-subsection">
+              <h4>CVE 5.1 cpeApplicability Structure:</h4>
+              <div class="code-block">
+                <pre>
+{
   "cpeApplicability": [
     {
       "nodes": [
@@ -399,43 +577,52 @@ def _has_cpe_applicability(cna):
       ]
     }
   ]
-}</pre>
-            </div>
-            <p style="margin-top: 1rem; color: var(--text-secondary);">
-              The <code>cpeApplicability</code> field provides NVD-style CPE matching with operators and version ranges, 
-              enabling more precise vulnerability applicability statements than simple CPE lists.
-            </p>
-          </div>
-        </div>
-        
-        <!-- Patch Information Technical Details -->
-        <div class="tech-category" id="patch-information-tech">
-          <h3><span class="category-points">10 points</span> Patch Information - Technical Implementation</h3>
-          
-          <div class="tech-subsection">
-            <h4>Schema Field Paths Checked:</h4>
-            <div class="code-block">
-              <code>containers.cna.references[].tags</code> (array of strings)
+}</pre
+                >
+              </div>
+              <p style="margin-top: 1rem; color: var(--text-secondary)">
+                The <code>cpeApplicability</code> field provides NVD-style CPE
+                matching with operators and version ranges, enabling more
+                precise vulnerability applicability statements than simple CPE
+                lists.
+              </p>
             </div>
           </div>
-          
-          <div class="tech-subsection">
-            <h4>Validation Logic:</h4>
-            <div class="validation-rule">
-              <strong>Binary Scoring:</strong> Either 10 points or 0 points
+
+          <!-- Patch Information Technical Details -->
+          <div class="tech-category" id="patch-information-tech">
+            <h3>
+              <span class="category-points">10 points</span> Patch Information -
+              Technical Implementation
+            </h3>
+
+            <div class="tech-subsection">
+              <h4>Schema Field Paths Checked:</h4>
+              <div class="code-block">
+                <code>containers.cna.references[].tags</code> (array of strings)
+              </div>
             </div>
-            <div class="validation-rule">
-              <strong>Tag Matching:</strong> Case-insensitive search for "patch" in any tag string
+
+            <div class="tech-subsection">
+              <h4>Validation Logic:</h4>
+              <div class="validation-rule">
+                <strong>Binary Scoring:</strong> Either 10 points or 0 points
+              </div>
+              <div class="validation-rule">
+                <strong>Tag Matching:</strong> Case-insensitive search for
+                "patch" in any tag string
+              </div>
+              <div class="validation-rule">
+                <strong>Search Process:</strong> Iterates through all references
+                → tags arrays
+              </div>
             </div>
-            <div class="validation-rule">
-              <strong>Search Process:</strong> Iterates through all references → tags arrays
-            </div>
-          </div>
-          
-          <div class="tech-subsection">
-            <h4>Code Implementation:</h4>
-            <div class="code-block">
-<pre>def _calculate_actionable_intelligence(cve, cna):
+
+            <div class="tech-subsection">
+              <h4>Code Implementation:</h4>
+              <div class="code-block">
+                <pre>
+def _calculate_actionable_intelligence(cve, cna):
     references = cna.get('references', [])
     if not isinstance(references, list):
         return 0
@@ -457,19 +644,21 @@ def _has_patch_references(references):
             if isinstance(tag, str) and 'patch' in tag.lower():
                 return True
     
-    return False</pre>
+    return False</pre
+                >
+              </div>
             </div>
           </div>
-        </div>
-        
-        <!-- Scoring Configuration -->
-        <div class="tech-category" id="scoring-configuration">
-          <h3>Scoring Configuration (rules.json)</h3>
-          
-          <div class="tech-subsection">
-            <h4>Complete Scoring Rules:</h4>
-            <div class="code-block">
-<pre>{
+
+          <!-- Scoring Configuration -->
+          <div class="tech-category" id="scoring-configuration">
+            <h3>Scoring Configuration (rules.json)</h3>
+
+            <div class="tech-subsection">
+              <h4>Complete Scoring Rules:</h4>
+              <div class="code-block">
+                <pre>
+{
   "foundationalCompleteness": {
     "weight": 50,
     "criteria": ["descriptions", "affected", "references"],
@@ -495,258 +684,392 @@ def _has_patch_references(references):
     "criteria": ["patchRef"],
     "binary": true
   }
-}</pre>
+}</pre
+                >
+              </div>
+            </div>
+          </div>
+
+          <!-- Verification Instructions -->
+          <div class="tech-category" id="verification-instructions">
+            <h3>Verification Instructions for CNAs</h3>
+
+            <div class="tech-subsection">
+              <h4>How to Verify Your CVE Scoring:</h4>
+              <ol class="verification-steps">
+                <li>
+                  <strong>Download your CVE JSON:</strong> Get the official CVE
+                  record from the CVE database
+                </li>
+                <li>
+                  <strong>Check field paths:</strong> Verify the exact schema
+                  paths listed above exist in your JSON
+                </li>
+                <li>
+                  <strong>Validate content:</strong> Ensure arrays are non-empty
+                  and contain valid data
+                </li>
+                <li>
+                  <strong>Test scoring logic:</strong> Apply the binary scoring
+                  rules to calculate expected points
+                </li>
+                <li>
+                  <strong>Compare results:</strong> Match against your CNA
+                  scorecard results
+                </li>
+              </ol>
+            </div>
+
+            <div class="tech-subsection">
+              <h4>Common Issues and Solutions:</h4>
+              <div class="issue-solution">
+                <strong>Issue:</strong> Missing foundational completeness
+                points<br />
+                <strong>Check:</strong> Ensure all three arrays (descriptions,
+                affected, references) exist and are non-empty
+              </div>
+              <div class="issue-solution">
+                <strong>Issue:</strong> Missing root cause analysis points<br />
+                <strong>Check:</strong> Verify CWE ID format is "CWE-[number]"
+                and exists in official CWE database
+              </div>
+              <div class="issue-solution">
+                <strong>Issue:</strong> Missing severity context points<br />
+                <strong>Check:</strong> Ensure CVSS object contains valid
+                vectorString field
+              </div>
+              <div class="issue-solution">
+                <strong>Issue:</strong> Missing software identification
+                points<br />
+                <strong>Check:</strong> Verify at least one affected product has
+                non-empty cpes array OR the cpeApplicability field contains
+                valid CPE match data with criteria strings
+              </div>
+              <div class="issue-solution">
+                <strong>Issue:</strong> Missing patch information points<br />
+                <strong>Check:</strong> Ensure at least one reference has
+                "patch" in its tags array
+              </div>
             </div>
           </div>
         </div>
-        
-        <!-- Verification Instructions -->
-        <div class="tech-category" id="verification-instructions">
-          <h3>Verification Instructions for CNAs</h3>
-          
-          <div class="tech-subsection">
-            <h4>How to Verify Your CVE Scoring:</h4>
-            <ol class="verification-steps">
-              <li><strong>Download your CVE JSON:</strong> Get the official CVE record from the CVE database</li>
-              <li><strong>Check field paths:</strong> Verify the exact schema paths listed above exist in your JSON</li>
-              <li><strong>Validate content:</strong> Ensure arrays are non-empty and contain valid data</li>
-              <li><strong>Test scoring logic:</strong> Apply the binary scoring rules to calculate expected points</li>
-              <li><strong>Compare results:</strong> Match against your CNA scorecard results</li>
-            </ol>
-          </div>
-          
-          <div class="tech-subsection">
-            <h4>Common Issues and Solutions:</h4>
-            <div class="issue-solution">
-              <strong>Issue:</strong> Missing foundational completeness points<br>
-              <strong>Check:</strong> Ensure all three arrays (descriptions, affected, references) exist and are non-empty
-            </div>
-            <div class="issue-solution">
-              <strong>Issue:</strong> Missing root cause analysis points<br>
-              <strong>Check:</strong> Verify CWE ID format is "CWE-[number]" and exists in official CWE database
-            </div>
-            <div class="issue-solution">
-              <strong>Issue:</strong> Missing severity context points<br>
-              <strong>Check:</strong> Ensure CVSS object contains valid vectorString field
-            </div>
-            <div class="issue-solution">
-              <strong>Issue:</strong> Missing software identification points<br>
-              <strong>Check:</strong> Verify at least one affected product has non-empty cpes array OR the cpeApplicability field contains valid CPE match data with criteria strings
-            </div>
-            <div class="issue-solution">
-              <strong>Issue:</strong> Missing patch information points<br>
-              <strong>Check:</strong> Ensure at least one reference has "patch" in its tags array
-            </div>
-          </div>
-        </div>
-        
-      </div>
-    </section>
+      </section>
 
-    <!-- Grading Tiers Section -->
-    <section class="grading-tiers-card card">
-      <h2>Grading Tiers</h2>
-      <p class="grading-intro">
-        Scores are calculated as a percentage of total possible points (100), then mapped to letter grades for easy interpretation:
-      </p>
-      <div class="grading-table">
-        <div class="grade-row">
-          <span class="badge-grade badge-perfect">Perfect</span>
-          <span class="grade-percentage">100%</span>
-          <span class="grade-description">All essential data fields are complete and accurate</span>
-        </div>
-        <div class="grade-row">
-          <span class="badge-grade badge-great">Great</span>
-          <span class="grade-percentage">&gt;75%</span>
-          <span class="grade-description">Most critical information is provided with minor gaps</span>
-        </div>
-        <div class="grade-row">
-          <span class="badge-grade badge-good">Good</span>
-          <span class="grade-percentage">&gt;50%</span>
-          <span class="grade-description">Basic requirements met with room for improvement</span>
-        </div>
-        <div class="grade-row">
-          <span class="badge-grade badge-needs-work">Needs Work</span>
-          <span class="grade-percentage">&lt;50%</span>
-          <span class="grade-description">Significant gaps in essential vulnerability data</span>
-        </div>
-        <div class="grade-row">
-          <span class="badge-grade badge-missing">Missing Data</span>
-          <span class="grade-percentage">0%</span>
-          <span class="grade-description">No scoring data available for this CNA</span>
-        </div>
-      </div>
-    </section>
-
-    <!-- Performance Trends Section -->
-    <section class="scoring-categories-card card">
-      <h2>Performance Trends Analysis</h2>
-      <p class="categories-intro">
-        Beyond point-in-time scoring, the CNA Scorecard tracks performance trends over time using rolling 7-day averages 
-        to identify patterns and improvements in vulnerability data quality.
-      </p>
-      
-      <div class="category-detail">
-        <h3>Rolling 7-Day Averages</h3>
-        <p class="category-what"><strong>What it tracks:</strong> Daily average scores for each scoring category calculated over sliding 7-day windows, updated daily for the past 6 months.</p>
-        <p class="category-why"><strong>Why it matters:</strong> Smooths out daily fluctuations to reveal genuine trends in data quality improvement or decline. A single bad day doesn't define overall performance.</p>
-        <p class="category-how"><strong>How it works:</strong> Each day's score represents the average of the previous 7 days, creating a smooth trend line that highlights meaningful patterns over noise.</p>
-      </div>
-      
-      <div class="category-detail">
-        <h3>Top Improving CNAs</h3>
-        <p class="category-what"><strong>What it identifies:</strong> CNAs showing the most significant improvement by comparing their earliest versus most recent 7-day performance averages over a 6-month analysis period.</p>
-        <p class="category-why"><strong>Why it's valuable:</strong> Recognizes CNAs making genuine efforts to improve their vulnerability reporting practices and helps identify best practices worth emulating.</p>
-        <p class="category-how"><strong>How it's calculated:</strong> Improvement score equals the difference between the most recent 7-day average and the earliest 7-day average for each CNA with sufficient data.</p>
-      </div>
-      
-      <div class="category-detail">
-        <h3>Trend Visualization</h3>
-        <p class="category-what"><strong>What it shows:</strong> Interactive line charts displaying rolling averages for Root Cause Analysis (CWE), Severity & Impact (CVSS), Software Identification (CPE), and Patch Information categories.</p>
-        <p class="category-why"><strong>Why separate charts:</strong> Each scoring category has different typical ranges and improvement patterns, requiring dedicated visualization for meaningful analysis.</p>
-        <p class="category-how"><strong>How it adapts:</strong> Charts use auto-scaling Y-axes that adjust to actual data ranges, ensuring trend visibility whether scores are high-performing or need improvement.</p>
-      </div>
-      
-      <div class="centered-cta">
-        <a href="trends.html" class="cta-button secondary">View Performance Trends Dashboard</a>
-      </div>
-    </section>
-
-    <!-- CNA Badges Section -->
-    <section class="methodology-notes-card card" style="text-align: left;">
-      <h2 style="text-align: left;">CNA Scorecard Badges</h2>
-      <p>
-        CNAs can display their CNA Scorecard rating on their website, README, or documentation using automatically-generated SVG badges. 
-        Badges are updated every time the pipeline runs, so they always reflect the latest score and rank.
-      </p>
-      <div style="margin: 1.5rem 0; padding: 1.5rem; background: #f5f5f5; border-radius: 8px; border-left: 4px solid var(--primary-color);">
-        <h3 style="margin-top: 0; color: var(--primary-color);">Three Badge Styles Available:</h3>
-        <div style="line-height: 1.8;">
-          <div><strong>Rank Badge</strong> - Shows CNA rank (e.g., #1, #5, #42)</div>
-          <div><strong>Score Badge</strong> - Shows percentage score (e.g., 95.0%)</div>
-          <div><strong>Combined Badge</strong> - Shows both rank and score (e.g., #1 - 95.0%)</div>
-        </div>
-        <p style="margin-bottom: 0;">
-          <strong>🎯 Get Your Badge:</strong> 
-          <a href="badges.html" style="color: var(--primary-color); font-weight: 600;">Visit the Badge Generator →</a>
+      <!-- Grading Tiers Section -->
+      <section class="grading-tiers-card card">
+        <h2>Grading Tiers</h2>
+        <p class="grading-intro">
+          Scores are calculated as a percentage of total possible points (100),
+          then mapped to letter grades for easy interpretation:
         </p>
-      </div>
-      <p style="color: var(--text-secondary); font-style: italic; text-align: left;">
-        Badges are color-coded based on score (green for 90-100%, blue for 70-79%, yellow for 60-69%, red below 60%) 
-        to provide quick visual feedback on performance.
-      </p>
-    </section>
+        <div class="grading-table">
+          <div class="grade-row">
+            <span class="badge-grade badge-perfect">Perfect</span>
+            <span class="grade-percentage">100%</span>
+            <span class="grade-description"
+              >All essential data fields are complete and accurate</span
+            >
+          </div>
+          <div class="grade-row">
+            <span class="badge-grade badge-great">Great</span>
+            <span class="grade-percentage">&gt;75%</span>
+            <span class="grade-description"
+              >Most critical information is provided with minor gaps</span
+            >
+          </div>
+          <div class="grade-row">
+            <span class="badge-grade badge-good">Good</span>
+            <span class="grade-percentage">&gt;50%</span>
+            <span class="grade-description"
+              >Basic requirements met with room for improvement</span
+            >
+          </div>
+          <div class="grade-row">
+            <span class="badge-grade badge-needs-work">Needs Work</span>
+            <span class="grade-percentage">&lt;50%</span>
+            <span class="grade-description"
+              >Significant gaps in essential vulnerability data</span
+            >
+          </div>
+          <div class="grade-row">
+            <span class="badge-grade badge-missing">Missing Data</span>
+            <span class="grade-percentage">0%</span>
+            <span class="grade-description"
+              >No scoring data available for this CNA</span
+            >
+          </div>
+        </div>
+      </section>
 
-    <!-- Transparency Section -->
-    <section class="methodology-notes-card card">
-      <h2>Transparency & Open Standards</h2>
-      <p class="transparency-statement">
-        The CNA Scorecard is committed to complete transparency in methodology. Every aspect of the scoring system is based on 
-        established industry standards and open specifications. The scoring logic is fully documented and publicly 
-        available, ensuring that CNAs and security professionals can understand exactly how scores are calculated.
-      </p>
-      <p class="open-source-note">
-        All scoring algorithms, data processing methods, and evaluation criteria are open source and available for 
-        review in the <a href="https://github.com/jgamblin/CNAScoreCard" target="_blank">project repository</a>. 
-        Feedback and contributions from the security community are welcome to continuously improve the methodology.
-      </p>
-    </section>
-  </main>
-  <footer class="footer">
-    <div class="footer-main">
-      <div class="footer-brand">
-        <img src="assets/logo.svg" alt="CNA Scorecard Logo" class="footer-logo">
-        <span class="footer-title">CNA Scorecard</span>
+      <!-- Performance Trends Section -->
+      <section class="scoring-categories-card card">
+        <h2>Performance Trends Analysis</h2>
+        <p class="categories-intro">
+          Beyond point-in-time scoring, the CNA Scorecard tracks performance
+          trends over time using rolling 7-day averages to identify patterns and
+          improvements in vulnerability data quality.
+        </p>
+
+        <div class="category-detail">
+          <h3>Rolling 7-Day Averages</h3>
+          <p class="category-what">
+            <strong>What it tracks:</strong> Daily average scores for each
+            scoring category calculated over sliding 7-day windows, updated
+            daily for the past 6 months.
+          </p>
+          <p class="category-why">
+            <strong>Why it matters:</strong> Smooths out daily fluctuations to
+            reveal genuine trends in data quality improvement or decline. A
+            single bad day doesn't define overall performance.
+          </p>
+          <p class="category-how">
+            <strong>How it works:</strong> Each day's score represents the
+            average of the previous 7 days, creating a smooth trend line that
+            highlights meaningful patterns over noise.
+          </p>
+        </div>
+
+        <div class="category-detail">
+          <h3>Top Improving CNAs</h3>
+          <p class="category-what">
+            <strong>What it identifies:</strong> CNAs showing the most
+            significant improvement by comparing their earliest versus most
+            recent 7-day performance averages over a 6-month analysis period.
+          </p>
+          <p class="category-why">
+            <strong>Why it's valuable:</strong> Recognizes CNAs making genuine
+            efforts to improve their vulnerability reporting practices and helps
+            identify best practices worth emulating.
+          </p>
+          <p class="category-how">
+            <strong>How it's calculated:</strong> Improvement score equals the
+            difference between the most recent 7-day average and the earliest
+            7-day average for each CNA with sufficient data.
+          </p>
+        </div>
+
+        <div class="category-detail">
+          <h3>Trend Visualization</h3>
+          <p class="category-what">
+            <strong>What it shows:</strong> Interactive line charts displaying
+            rolling averages for Root Cause Analysis (CWE), Severity & Impact
+            (CVSS), Software Identification (CPE), and Patch Information
+            categories.
+          </p>
+          <p class="category-why">
+            <strong>Why separate charts:</strong> Each scoring category has
+            different typical ranges and improvement patterns, requiring
+            dedicated visualization for meaningful analysis.
+          </p>
+          <p class="category-how">
+            <strong>How it adapts:</strong> Charts use auto-scaling Y-axes that
+            adjust to actual data ranges, ensuring trend visibility whether
+            scores are high-performing or need improvement.
+          </p>
+        </div>
+
+        <div class="centered-cta">
+          <a href="trends.html" class="cta-button secondary"
+            >View Performance Trends Dashboard</a
+          >
+        </div>
+      </section>
+
+      <!-- CNA Badges Section -->
+      <section class="methodology-notes-card card" style="text-align: left">
+        <h2 style="text-align: left">CNA Scorecard Badges</h2>
+        <p>
+          CNAs can display their CNA Scorecard rating on their website, README,
+          or documentation using automatically-generated SVG badges. Badges are
+          updated every time the pipeline runs, so they always reflect the
+          latest score and rank.
+        </p>
+        <div
+          style="
+            margin: 1.5rem 0;
+            padding: 1.5rem;
+            background: #f5f5f5;
+            border-radius: 8px;
+            border-left: 4px solid var(--primary-color);
+          "
+        >
+          <h3 style="margin-top: 0; color: var(--primary-color)">
+            Three Badge Styles Available:
+          </h3>
+          <div style="line-height: 1.8">
+            <div>
+              <strong>Rank Badge</strong> - Shows CNA rank (e.g., #1, #5, #42)
+            </div>
+            <div>
+              <strong>Score Badge</strong> - Shows percentage score (e.g.,
+              95.0%)
+            </div>
+            <div>
+              <strong>Combined Badge</strong> - Shows both rank and score (e.g.,
+              #1 - 95.0%)
+            </div>
+          </div>
+          <p style="margin-bottom: 0">
+            <strong>🎯 Get Your Badge:</strong>
+            <a
+              href="badges.html"
+              style="color: var(--primary-color); font-weight: 600"
+              >Visit the Badge Generator →</a
+            >
+          </p>
+        </div>
+        <p
+          style="
+            color: var(--text-secondary);
+            font-style: italic;
+            text-align: left;
+          "
+        >
+          Badges are color-coded based on score (green for 90-100%, blue for
+          70-79%, yellow for 60-69%, red below 60%) to provide quick visual
+          feedback on performance.
+        </p>
+      </section>
+
+      <!-- Transparency Section -->
+      <section class="methodology-notes-card card">
+        <h2>Transparency & Open Standards</h2>
+        <p class="transparency-statement">
+          The CNA Scorecard is committed to complete transparency in
+          methodology. Every aspect of the scoring system is based on
+          established industry standards and open specifications. The scoring
+          logic is fully documented and publicly available, ensuring that CNAs
+          and security professionals can understand exactly how scores are
+          calculated.
+        </p>
+        <p class="open-source-note">
+          All scoring algorithms, data processing methods, and evaluation
+          criteria are open source and available for review in the
+          <a href="https://github.com/jgamblin/CNAScoreCard" target="_blank"
+            >project repository</a
+          >. Feedback and contributions from the security community are welcome
+          to continuously improve the methodology.
+        </p>
+      </section>
+    </main>
+    <footer class="footer">
+      <div class="footer-main">
+        <div class="footer-brand">
+          <img
+            src="assets/logo.svg"
+            alt="CNA Scorecard Logo"
+            class="footer-logo"
+          />
+          <span class="footer-title">CNA Scorecard</span>
+        </div>
+        <div class="footer-links">
+          <a href="https://github.com/RogoLabs/CNAScoreCard" target="_blank"
+            >GitHub</a
+          >
+          <a href="https://rogolabs.net" target="_blank">RogoLabs</a>
+          <a href="https://patchthis.app" target="_blank">PatchThis</a>
+          <a href="https://cveforecast.org" target="_blank">CVEForecast</a>
+          <a href="https://cve.icu" target="_blank">CVE.ICU</a>
+        </div>
       </div>
-      <div class="footer-links">
-        <a href="https://github.com/RogoLabs/CNAScoreCard" target="_blank">GitHub</a>
-        <a href="https://rogolabs.net" target="_blank">RogoLabs</a>
-        <a href="https://patchthis.app" target="_blank">PatchThis</a>
-        <a href="https://cveforecast.org" target="_blank">CVEForecast</a>
-        <a href="https://cve.icu" target="_blank">CVE.ICU</a>
-      </div>
-    </div>
-    <div class="footer-meta">&copy; 2025 RogoLabs. All rights reserved.</div>
-  </footer>
-  <script>
-    // Utility function for date formatting (same as homepage)
-    function formatDateRange(dateRangeString) {
-      try {
-        const parts = dateRangeString.split(' to ');
-        if (parts.length !== 2) return dateRangeString;
-        
-        // Parse as UTC to avoid timezone conversion issues
-        const startDate = new Date(parts[0] + 'T12:00:00Z');
-        const endDate = new Date(parts[1] + 'T12:00:00Z');
-        
-        const formatDate = (date) => {
-          const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-                         'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-          
-          const day = date.getDate();
-          const month = months[date.getMonth()];
-          const year = date.getFullYear();
-          
-          // Add ordinal suffix (st, nd, rd, th)
-          const getOrdinal = (n) => {
-            const s = ['th', 'st', 'nd', 'rd'];
-            const v = n % 100;
-            return n + (s[(v - 20) % 10] || s[v] || s[0]);
+      <div class="footer-meta">&copy; 2025 RogoLabs. All rights reserved.</div>
+    </footer>
+    <script>
+      // Utility function for date formatting (same as homepage)
+      function formatDateRange(dateRangeString) {
+        try {
+          const parts = dateRangeString.split(" to ");
+          if (parts.length !== 2) return dateRangeString;
+
+          // Parse as UTC to avoid timezone conversion issues
+          const startDate = new Date(parts[0] + "T12:00:00Z");
+          const endDate = new Date(parts[1] + "T12:00:00Z");
+
+          const formatDate = (date) => {
+            const months = [
+              "Jan",
+              "Feb",
+              "Mar",
+              "Apr",
+              "May",
+              "Jun",
+              "Jul",
+              "Aug",
+              "Sep",
+              "Oct",
+              "Nov",
+              "Dec",
+            ];
+
+            const day = date.getDate();
+            const month = months[date.getMonth()];
+            const year = date.getFullYear();
+
+            // Add ordinal suffix (st, nd, rd, th)
+            const getOrdinal = (n) => {
+              const s = ["th", "st", "nd", "rd"];
+              const v = n % 100;
+              return n + (s[(v - 20) % 10] || s[v] || s[0]);
+            };
+
+            return `${month} ${getOrdinal(day)}, ${year}`;
           };
-          
-          return `${month} ${getOrdinal(day)}, ${year}`;
-        };
-        
-        return `${formatDate(startDate)} – ${formatDate(endDate)}`;
-      } catch (error) {
-        console.error('Error formatting date range:', error);
-        return dateRangeString;
+
+          return `${formatDate(startDate)} – ${formatDate(endDate)}`;
+        } catch (error) {
+          console.error("Error formatting date range:", error);
+          return dateRangeString;
+        }
       }
-    }
-    
-    // Load and display current analysis period
-    async function loadAnalysisPeriod() {
-      try {
-        const response = await fetch('./data/completeness_summary.json');
-        const data = await response.json();
-        
-        const rawPeriod = data.analysis_period || 'Not available';
-        const formattedPeriod = rawPeriod !== 'Not available' ? formatDateRange(rawPeriod) : rawPeriod;
-        
-        document.getElementById('currentPeriod').textContent = formattedPeriod;
-      } catch (error) {
-        console.error('Error loading analysis period:', error);
-        document.getElementById('currentPeriod').textContent = 'Unable to load current period';
+
+      // Load and display current analysis period
+      async function loadAnalysisPeriod() {
+        try {
+          const response = await fetch("./data/completeness_summary.json");
+          const data = await response.json();
+
+          const rawPeriod = data.analysis_period || "Not available";
+          const formattedPeriod =
+            rawPeriod !== "Not available"
+              ? formatDateRange(rawPeriod)
+              : rawPeriod;
+
+          document.getElementById("currentPeriod").textContent =
+            formattedPeriod;
+        } catch (error) {
+          console.error("Error loading analysis period:", error);
+          document.getElementById("currentPeriod").textContent =
+            "Unable to load current period";
+        }
       }
-    }
-    
-    // Load the analysis period when the page loads
-    document.addEventListener('DOMContentLoaded', loadAnalysisPeriod);
-    
-    // Technical details toggle functionality
-    document.addEventListener('DOMContentLoaded', function() {
-      const toggleButton = document.getElementById('toggleTechnicalDetails');
-      const technicalDetails = document.getElementById('technicalDetails');
-      
-      if (toggleButton && technicalDetails) {
-        toggleButton.addEventListener('click', function() {
-          const isVisible = technicalDetails.style.display !== 'none';
-          
-          if (isVisible) {
-            // Hide technical details
-            technicalDetails.style.display = 'none';
-            toggleButton.textContent = 'Show Technical Details';
-            toggleButton.classList.remove('expanded');
-          } else {
-            // Show technical details
-            technicalDetails.style.display = 'block';
-            toggleButton.textContent = 'Hide Technical Details';
-            toggleButton.classList.add('expanded');
-          }
-        });
-      }
-    });
-  </script>
-  <script src="shared/mobile-nav.js"></script>
-</body>
+
+      // Load the analysis period when the page loads
+      document.addEventListener("DOMContentLoaded", loadAnalysisPeriod);
+
+      // Technical details toggle functionality
+      document.addEventListener("DOMContentLoaded", function () {
+        const toggleButton = document.getElementById("toggleTechnicalDetails");
+        const technicalDetails = document.getElementById("technicalDetails");
+
+        if (toggleButton && technicalDetails) {
+          toggleButton.addEventListener("click", function () {
+            const isVisible = technicalDetails.style.display !== "none";
+
+            if (isVisible) {
+              // Hide technical details
+              technicalDetails.style.display = "none";
+              toggleButton.textContent = "Show Technical Details";
+              toggleButton.classList.remove("expanded");
+            } else {
+              // Show technical details
+              technicalDetails.style.display = "block";
+              toggleButton.textContent = "Hide Technical Details";
+              toggleButton.classList.add("expanded");
+            }
+          });
+        }
+      });
+    </script>
+    <script src="shared/mobile-nav.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- Updated the scoring page and index to accurately describe that only the `patch` reference tag is checked when scoring Patch Information
- Previous wording ("links to patches, fixes, or official vendor advisories") was broader than what the code actually evaluates
- Now explicitly notes that tags like `vendor-advisory` are not currently counted

Addresses [discussion #27](https://github.com/RogoLabs/CNAScoreCard/discussions/27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)